### PR TITLE
Hotfix/open5gs vm

### DIFF
--- a/open5gs_vm/result_templates/ok_result.md.j2
+++ b/open5gs_vm/result_templates/ok_result.md.j2
@@ -43,8 +43,8 @@ Current versions:
 - **TAC**: `{{ one_open5gs_vm_tac }}`
 - **S-NSSAI (SST)**: `{{ one_open5gs_vm_s_nssai_sst }}`
 - **S-NSSAI (SD)**: `{{ one_open5gs_vm_s_nssai_sd }}`
-- **AMF IP**: `{{ open5gs_metadata_dict['n2_ip'] }}`
-- **UPF IP**: `{{ open5gs_metadata_dict['n3_ip'] }}`
+- **AMF IP**: `{{ open5gs_metadata_dict['amf_ip'] }}`
+- **UPF IP**: `{{ open5gs_metadata_dict['upf_ip'] }}`
 - **Web portal URL**: `{{ one_open5gs_vm_webui_subdomain | default("UNDEFINED") }}.{{ tn_id }}.{{ site_domain }}`
 - **Web portal credentials**: 
   - `admin`


### PR DESCRIPTION
This PR fixes the dict variable access in the Report generation.

error: `msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''n2_ip'''`