### PR TITLE
Hotfix/open5gcore + ueransim

### DIFF
--- a/open5gcore_vm/TN_open5gcore-ueransim.yaml
+++ b/open5gcore_vm/TN_open5gcore-ueransim.yaml
@@ -4,15 +4,18 @@ trial_network:
 
   tn_init:
     type: "tn_init"
-    dependencies: []
-    input: {}
+    dependencies: ["vnet-n2"]
+    input:
+      one_bastion_networks:
+        - tn_vxlan
+        - "vnet-n2"
   vnet-n2:
     type: "vnet"
     name: "n2"
-    dependencies:
-      - "tn_init"
+    dependencies: []
+      #- "tn_init"
     input:
-      one_vnet_first_ip: "10.10.10.2"
+      one_vnet_first_ip: "10.10.10.1"
       one_vnet_netmask: "255.255.255.0"
       one_vnet_address_size: 253
       one_vnet_gw: "" # there is no gateway in this network
@@ -64,8 +67,8 @@ trial_network:
       - "open5gcore_vm-core"
     input:
       one_ueransim_networks:
-        - "tn_vxlan"
         - "vnet-n2"
+        - "tn_vxlan"
       one_ueransim_run_gnb: "YES"
       one_ueransim_run_ue: "YES"
       one_ueransim_gnb_linked_open5gs: "open5gcore_vm-core"

--- a/open5gcore_vm/TN_open5gcore-ueransim.yaml
+++ b/open5gcore_vm/TN_open5gcore-ueransim.yaml
@@ -5,12 +5,7 @@ trial_network:
   tn_init:
     type: "tn_init"
     dependencies: []
-    input:
-      one_vxlan_gw: "192.168.197.1"
-      one_vxlan_netmask: "255.255.255.0"
-      one_vxlan_dns: "1.1.1.1 8.8.8.8"
-      one_vxlan_first_ip: "192.168.197.1"
-      one_vxlan_address_size: 254
+    input: {}
   vnet-n2:
     type: "vnet"
     name: "n2"
@@ -66,7 +61,7 @@ trial_network:
     dependencies:
       - "tn_init"
       - "vnet-n2"
-      - "open5gs_vm-core"
+      - "open5gcore_vm-core"
     input:
       one_ueransim_networks:
         - "tn_vxlan"

--- a/open5gcore_vm/code/component_playbook.yaml
+++ b/open5gcore_vm/code/component_playbook.yaml
@@ -138,6 +138,8 @@
       ansible.builtin.set_fact:
         open5gcore_metadata_dict: >-
           {
+            'oneKE': '',
+            'proxy': '',
             'mcc': '{{ one_open5gcore_vm_mcc }}',
             'mnc': '{{ one_open5gcore_vm_mnc }}',
             'msin': '{{ one_open5gcore_vm_msin }}',


### PR DESCRIPTION
- Expose empty `proxy` and `oneKE` values in 5g-core metadata as this is needed to be present if linked to ueransim 
- use default network cidr for tn_vxlan
- attach vnet-n2 to bastion and use this network s first network for ueransim as a workaround for a binding bug in ueransim applience

this PR needs #75 to work