### PR TITLE
Hotfix/ueransim gnbseachlist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
 - Updated `loadcore` to use new appliance with OpenNebula contextualization scripts. However, IaC is currently broken. VM is deployed by Ansible itself
 - Updated `ueransim` the field `one_ueransim_gnb_linked_open5gs` to support `upf_p4_sw` component.
 - Metadata appliances url.
+- Updated `ueransim-ue` config to correctly reach the gnb in the same VM when in BOTH mode
+
 ## Fixed
 - Component TSN: markdown report file `ok_result.md.j2`.
 - Fixed bug where the one_open5gs_upf_ip wasn't correctly set as an output variable

--- a/ueransim/changelog.md
+++ b/ueransim/changelog.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Input variable `one_ueransim_gnb_linked_open5gs` now supports both `upf_p4_sw` and `open5gs_vm` and `open5gcore_vm` as component type.
+- Fix `gnbSearchList` of the ueransim-UE to use the correct ip address of the componnet when in BOTH mode (Temporary fix until the appliance is fixed)
 
 ## [v0.3.0]
 ### Fixed

--- a/ueransim/code/component_playbook.yaml
+++ b/ueransim/code/component_playbook.yaml
@@ -68,7 +68,8 @@
         - "{{ hostvars['localhost'].get('site_admin_ssh_public_key', '') }}"
       when: item != ''
 
-    - name: fix UE config
+    ## This is removed when the appliance is updated to handle this case correctly
+    - name: (TEMPORARY) fix UE config
       vars:
         ips: "{{ hostvars['localhost']['ips'] }}"
         access_vnet_id: "{{ hostvars['localhost']['access_vnet_id'] }}"

--- a/ueransim/code/component_playbook.yaml
+++ b/ueransim/code/component_playbook.yaml
@@ -68,6 +68,24 @@
         - "{{ hostvars['localhost'].get('site_admin_ssh_public_key', '') }}"
       when: item != ''
 
+    - name: fix UE config
+      vars:
+        ips: "{{ hostvars['localhost']['ips'] }}"
+        access_vnet_id: "{{ hostvars['localhost']['access_vnet_id'] }}"
+        access_vnet_ip: "{{ ips[access_vnet_id] }}"
+      when: hostvars['localhost'].get('one_ueransim_run_ue', 'NO') == 'YES' and hostvars['localhost'].get('one_ueransim_run_gnb', 'NO') == 'YES'
+      become: true
+      block:
+        - name: update gnbSearchList in UE config
+          ansible.builtin.shell:
+          args:
+            chdir: "/etc/ueransim"
+            cmd: "yq '.gnbSearchList = [\"{{ access_vnet_ip }}\"]' -i open5gs-ue.yaml"
+        - name: restart UE
+          service:
+            name: ueransim-ue
+            state: restarted
+
     - name: Create new user for experimenter access
       become: true
       ansible.builtin.user:


### PR DESCRIPTION
This adds ansible steps to the CaC stage to update the gnbSearchList of the ueran-ue to include the external ip of the componnet which is configured in the GNB as linkIp.

