### PR TITLE
Feature/open5gcore webCLI +MTU fixes +ue-route on bastion

### DIFF
--- a/open5gcore_vm/TN_open5gcore-loadcore.yaml
+++ b/open5gcore_vm/TN_open5gcore-loadcore.yaml
@@ -59,6 +59,7 @@ trial_network:
       one_open5gcore_vm_amf_ip: "10.10.10.200"
       one_open5gcore_vm_upf_ip: "10.10.10.201"
       one_open5gcore_vm_ue_count: 20
+      #one_open5gcore_vm_upf_xdp: false
 #######
   loadcore_agent-dn:
     type: "loadcore_agent"

--- a/open5gcore_vm/TN_open5gcore-ueransim.yaml
+++ b/open5gcore_vm/TN_open5gcore-ueransim.yaml
@@ -57,6 +57,7 @@ trial_network:
       one_open5gcore_vm_amf_ip: "10.10.10.200"
       one_open5gcore_vm_upf_ip: "10.10.10.201"
       one_open5gcore_vm_ue_count: 20
+      #one_open5gcore_vm_upf_xdp: false
 #######
   ueransim-both:
     type: "ueransim"

--- a/open5gcore_vm/changelog.md
+++ b/open5gcore_vm/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [v1.0.0]
 
 ### Added
 

--- a/open5gcore_vm/changelog.md
+++ b/open5gcore_vm/changelog.md
@@ -5,6 +5,11 @@
 ### Added
 
 - initial version of Open5gCore VM compoent
+- Add Caddy to expose the WebCLI of Open5GCore
+
+### Changed
+
+- Change default MTU on DN network to 1406 to work with tn_vxlan GUEST_MTU of 1450
 
 
 <!-- Change latest version value at every release -->

--- a/open5gcore_vm/changelog.md
+++ b/open5gcore_vm/changelog.md
@@ -6,10 +6,11 @@
 
 - initial version of Open5gCore VM compoent
 - Add Caddy to expose the WebCLI of Open5GCore
+- Automatically configure a route on the `bastion` for the `ue_subnet` back to the core-VM
 
 ### Changed
 
-- Change default MTU on DN network to 1406 to work with tn_vxlan GUEST_MTU of 1450
+- Change default `MTU` on DN network to 1406 to work with tn_vxlan `GUEST_MTU` of 1450
 
 
 <!-- Change latest version value at every release -->

--- a/open5gcore_vm/code/any/cac/enable_routing_bastion.yaml
+++ b/open5gcore_vm/code/any/cac/enable_routing_bastion.yaml
@@ -1,7 +1,7 @@
 - name: Add routes in bastion
   vars:
     o5gcore_tn_vxlan_ip: "{{ hostvars['localhost']['ips'][hostvars['localhost']['access_vnet_id']]}}"
-  ansible.builtin.shell: "ip route add {{ item }}"
+  ansible.builtin.shell: "ip route add {{ item }} || ip route change {{ item }}"
   with_items:
     - "{{ one_open5gcore_vm_ue_subnet }} via {{ o5gcore_tn_vxlan_ip }}"
   become: yes

--- a/open5gcore_vm/code/any/cac/enable_routing_bastion.yaml
+++ b/open5gcore_vm/code/any/cac/enable_routing_bastion.yaml
@@ -1,0 +1,12 @@
+- name: Add routes in bastion
+  vars:
+    o5gcore_tn_vxlan_ip: "{{ hostvars['localhost']['ips'][hostvars['localhost']['access_vnet_id']]}}"
+  ansible.builtin.shell: "ip route add {{ item }}"
+  with_items:
+    - "{{ one_open5gcore_vm_ue_subnet }} via {{ o5gcore_tn_vxlan_ip }}"
+  become: yes
+
+#- name: add Routes via networkctl
+#  vars:
+#    bastion_tn_vxlan_if: "eth1"
+#    o5gcore_tn_vxlan_ip: "{{ hostvars['localhost']['ips'][hostvars['localhost']['access_vnet_id']]}}" #ips[access_vnet_id]

--- a/open5gcore_vm/code/component_playbook.yaml
+++ b/open5gcore_vm/code/component_playbook.yaml
@@ -65,10 +65,18 @@
           - n6_vnet_id
       when: debug
 
-    - name: "DEBUG: Display all variables/facts known for a host"
-      ansible.builtin.debug:
-        var: hostvars[inventory_hostname]
-      when: False
+    #- name: Add Route Manager to Ansible Inventory
+    #  ansible.builtin.add_host:
+    #    hostname: "routemanager"
+    #    ansible_host: "{{ site_available_components.nokia_radio.route_manager_ip1 }}"
+    #    ansible_user: "root"
+    #    ansible_ssh_private_key_file: "/var/lib/jenkins/.ssh/id_ed25519"
+
+    - name: Add the bastion to Ansible Inventory
+      ansible.builtin.add_host:
+        hostname: "bastion"
+        ansible_host: "{{ bastion_ip }}"
+        ansible_user: "jenkins"
 
     - name: Add new VM to Ansible Inventory
       ansible.builtin.add_host:
@@ -81,7 +89,7 @@
       ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/{{ site_hypervisor }}/cac/01_pre/ssh_config.yaml"
 
 
-- name: "STAGE 3: Apply CAC to prepare the component"
+- name: "STAGE 3: Apply CAC to prepare the component (open5gcore_vm)"
   hosts: "open5gcore_vm"
   gather_facts: false
   tasks:
@@ -118,16 +126,20 @@
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
 
-    - name: Display all variables/facts known for a host
-      ansible.builtin.debug:
-        var: hostvars[inventory_hostname]
-      when: False
-
     - name: Configure open5gcore
       vars:
         vm_ips: "{{ hostvars['localhost']['ips'] | dict2items(key_name='id', value_name='ip') }}"
       ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/{{ hostvars['localhost']['site_hypervisor'] }}/cac/02_install/setup-open5gcore.yaml"
 
+- name: "STAGE 3: Apply CaC to deploy the component - STEP 2 (bastion)"
+  hosts: "bastion"
+  gather_facts: false
+  tasks:
+    - name: Load enviromental variables from different sources inside the component
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+
+    - name: Enable routing path in Bastion
+      ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_bastion.yaml"
 
 - name: "STAGE 4: Publish execution results"
   hosts: localhost

--- a/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
@@ -73,11 +73,14 @@
       with_fileglob:
         - "sql/*.sh"
 
-    - name: copy helper script
+    - name: copy helper scripts
       copy:
-        src: "phoenix-journal-tmux.sh"
+        src: "{{ item }}"
         dest: "/usr/local/bin/"
         mode: +x
+      loop:
+        - "phoenix-journal-tmux.sh"
+        - "phoenix-env-export.sh"
 
     - name: generate add-test-ue
       template:

--- a/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
@@ -52,6 +52,7 @@
       with_items:
         - { src: 'open5gcore/systemd_env.j2', dest: '/etc/open5gcore/systemd_env' }
         - { src: 'open5gcore/env.sh.j2', dest: '/etc/open5gcore/env.sh' }
+        - { src: 'open5gcore/smf.json.j2', dest: '/etc/open5gcore/smf.json' }
         #- [ 'open5gcore/upf1_env.j2', '/etc/open5gcore/upf1_env' ]
         - { src: 'open5gcore/sql/udm_db.sql.j2', dest: '/etc/open5gcore/sql/udm_db.sql' }
         - { src: 'open5gcore/sql/zz_test_ue.sql.j2', dest: '/etc/open5gcore/sql/zz_test_ue.sql' }

--- a/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
@@ -22,15 +22,13 @@
         mode: 0600
         dest: /opt/phoenix/license.crt
 
-    - name: Copy sysctl.d/10-5g_forwarding.conf
+    - name: Copy sysctl files
       ansible.builtin.copy:
-        src: "sysctl_10-5g_forwarding.conf"
-        dest: /etc/sysctl.d/10-5g_forwarding.conf
-
-    - name: Copy sysctl.d/10-5g_forwarding.conf
-      ansible.builtin.copy:
-        src: "sysctl_20-5g_xdp.conf"
-        dest: /etc/sysctl.d/20-5g_xdp.conf
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      with_items:
+        - { src: 'sysctl_10-5g_forwarding.conf', dest: '/etc/sysctl.d/10-5g_forwarding.conf' }
+        - { src: 'sysctl_20-5g_xdp.conf',        dest: '/etc/sysctl.d/20-5g_xdp.conf' }
 
     - name: reload sysctl
       ansible.builtin.command:

--- a/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/configure-open5gcore.yaml
@@ -121,11 +121,14 @@
       changed_when: false
       when: networkd_changed.changed
 
-    - name: install phoenix@ service
+    - name: install services
       copy:
-        src: "phoenix@.service"
+        src: "{{ item }}"
         dest: /etc/systemd/system/
       register: systemdfiles
+      loop:
+        - "phoenix@.service"
+        - "open5gcore.service"
 
     - name: "systemd daemon-reload"
       ansible.builtin.systemd:
@@ -134,29 +137,13 @@
 
     - name: enable & start services
       service:
-        name: "{{ item }}"
+        name: "open5gcore"
         state: started
         enabled: true
-      loop:
-          - "phoenix@nrf"
-          - "phoenix@amf"
-          - "phoenix@smf"
-          - "phoenix@upf1"
-          - "phoenix@udm"
-          - "phoenix@ausf"
-          - "phoenix@pcf"
 
     - name: restart services
       service:
-        name: "{{ item }}"
+        name: "open5gcore"
         state: restarted
         enabled: true
-      loop:
-          - "phoenix@nrf"
-          - "phoenix@amf"
-          - "phoenix@smf"
-          - "phoenix@upf1"
-          - "phoenix@udm"
-          - "phoenix@ausf"
-          - "phoenix@pcf"
       when: systemdfiles.changed or config_changed.changed

--- a/open5gcore_vm/code/one/cac/02_install/files/caddy-open5gcore.service
+++ b/open5gcore_vm/code/one/cac/02_install/files/caddy-open5gcore.service
@@ -1,0 +1,34 @@
+# caddy.service
+#
+# For using Caddy with a config file.
+#
+# Make sure the ExecStart and ExecReload commands are correct
+# for your installation.
+#
+# See https://caddyserver.com/docs/install for instructions.
+#
+
+[Unit]
+Description=Caddy - for open5gcore CLI
+Documentation=https://caddyserver.com/docs/
+After=network.target network-online.target
+Requires=network-online.target
+
+[Service]
+Type=notify
+#User=caddy
+#Group=caddy
+
+#WorkingDirectory=/etc/open5gcore/caddy
+EnvironmentFile=/etc/open5gcore/systemd_env
+
+ExecStart=/usr/local/bin/caddy_server run --environ --config /etc/open5gcore/caddy/Caddyfile
+ExecReload=/usr/local/bin/caddy_server reload --config /etc/open5gcore/caddy/Caddyfile --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+PrivateTmp=true
+ProtectSystem=full
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/open5gcore_vm/code/one/cac/02_install/files/caddy/Caddyfile
+++ b/open5gcore_vm/code/one/cac/02_install/files/caddy/Caddyfile
@@ -1,0 +1,34 @@
+:80 {
+	handle_path /amf/* {
+		reverse_proxy {env.AMF_CP_IP}:8080
+	}
+	handle_path /nrf/* {
+		reverse_proxy {env.NRF_CP_IP}:8080
+	}
+	handle_path /gnb1/* {
+		reverse_proxy {env.GNB1_CP_IP}:8080
+	}
+	handle_path /upf1/* {
+		reverse_proxy {env.UPF1_MGMT_IP}:8080
+	}
+	handle_path /udm/* {
+		reverse_proxy {env.UDM_CP_IP}:8080
+	}
+	handle_path /pcf/* {
+		reverse_proxy {env.PCF_CP_IP}:8080
+	}
+	handle_path /ue1/* {
+		reverse_proxy {env.UE1_MGMT_IP}:8080
+	}
+	handle_path /ausf/* {
+		reverse_proxy {env.AUSF_CP_IP}:8080
+	}
+	handle_path /smf/* {
+		reverse_proxy {env.SMF_CP_IP}:8080
+	}
+
+	handle_path / {
+		root * /etc/open5gcore/caddy/index.html
+		file_server
+	}
+}

--- a/open5gcore_vm/code/one/cac/02_install/files/caddy/index.html
+++ b/open5gcore_vm/code/one/cac/02_install/files/caddy/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Open5GCore Reverse Proxy</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f9;
+        }
+        header {
+            background-color: #0073e6;
+            color: #fff;
+            padding: 20px 0;
+            text-align: center;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 2rem;
+        }
+        main {
+            padding: 20px;
+        }
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        ul li {
+            background: #fff;
+            margin: 10px 0;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        ul li a {
+            text-decoration: none;
+            color: #0073e6;
+            font-weight: bold;
+        }
+        ul li a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Open5GCore CLI landing page</h1>
+    </header>
+    <main>
+        <h2>NF Consoles</h2>
+        <ul>
+            <li><a href="/amf/console.html">AMF console</a></li>
+            <li><a href="/nrf/console.html">NRF console</a></li>
+            <!--li><a href="/gnb1/console.html">GNB1 console</a></li-->
+            <li><a href="/upf1/console.html">UPF1 console</a></li>
+            <li><a href="/udm/console.html">UDM console</a></li>
+            <li><a href="/pcf/console.html">PCF console</a></li>
+            <!--li><a href="/ue1/console.html">UE1 console</a></li-->
+            <li><a href="/ausf/console.html">AUSF console</a></li>
+            <li><a href="/smf/console.html">SMF console</a></li>
+        </ul>
+        <!--h2>Component UI</h2>
+        <ul>
+            <li><a href="/ue1/ue.html">UE UI</a></li>
+        </ul-->
+    </main>
+</body>
+</html>

--- a/open5gcore_vm/code/one/cac/02_install/files/open5gcore.service
+++ b/open5gcore_vm/code/one/cac/02_install/files/open5gcore.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Fraunhofer FOKUS Open5GCore 5G Core Network
+After=network-online.target mysql.service
+Wants=phoenix@nrf.service
+Wants=phoenix@amf.service
+Wants=phoenix@smf.service
+Wants=phoenix@upf1.service
+Wants=phoenix@udm.service
+Wants=phoenix@ausf.service
+Wants=phoenix@pcf.service
+
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/open5gcore_vm/code/one/cac/02_install/files/phoenix-env-export.sh
+++ b/open5gcore_vm/code/one/cac/02_install/files/phoenix-env-export.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+awk '/.*=.*/{print "export", $0}' /etc/open5gcore/*_env

--- a/open5gcore_vm/code/one/cac/02_install/files/phoenix@.service
+++ b/open5gcore_vm/code/one/cac/02_install/files/phoenix@.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=open5Gcore - %I
 #After=dev-%i.device systemd-user-sessions.service
+PartOf=open5gcore.service
 
 [Service]
 Type=simple
-#User=ubuntu
 
 EnvironmentFile=/etc/open5gcore/systemd_env
 # this one is optional
@@ -15,8 +15,9 @@ ConditionPathExists=/etc/open5gcore/%i.json
 
 ExecStart=/opt/phoenix/dist/bin/phoenix -j /etc/open5gcore/%i.json -l -p /opt/phoenix/dist/lib -i /tmp/phoenix-%i.pid
 
+TimeoutStopSec=8
 Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=open5gcore.service

--- a/open5gcore_vm/code/one/cac/02_install/install-caddy.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/install-caddy.yaml
@@ -1,10 +1,17 @@
 ---
-- name: download caddy (TEMPORARY until appliance is updated)
+- name: check if Caddy is already installed
+  stat:
+    path: /usr/local/bin/caddy_server
+  register: caddy_bin
+
+- name: download caddy
   become: true
   ansible.builtin.get_url:
     url: "https://caddyserver.com/api/download?os=linux&arch=amd64&idempotency=63113367019600"
     dest: /usr/local/bin/caddy_server
     mode: "+x"
+  when: not caddy_bin.stat.exists
+
 - name: create caddy directory
   file:
     path: "/etc/open5gcore/caddy"

--- a/open5gcore_vm/code/one/cac/02_install/install-caddy.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/install-caddy.yaml
@@ -1,0 +1,40 @@
+---
+- name: download caddy (TEMPORARY until appliance is updated)
+  become: true
+  ansible.builtin.get_url:
+    url: "https://caddyserver.com/api/download?os=linux&arch=amd64&idempotency=63113367019600"
+    dest: /usr/local/bin/caddy_server
+    mode: "+x"
+- name: create caddy directory
+  file:
+    path: "/etc/open5gcore/caddy"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: copy files
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    mode: 0660
+    dest: /etc/open5gcore/caddy/
+  loop:
+  - "caddy/Caddyfile"
+  - "caddy/index.html"
+
+- name: install caddy service
+  copy:
+    src: "caddy-open5gcore.service"
+    dest: /etc/systemd/system/
+  register: systemdfiles
+
+- name: "systemd daemon-reload"
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: systemdfiles.changed
+
+- name: enable & start services
+  service:
+    name: "caddy-open5gcore"
+    state: started
+    enabled: true

--- a/open5gcore_vm/code/one/cac/02_install/setup-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/setup-open5gcore.yaml
@@ -52,6 +52,9 @@
     - name: Configure open5gcore
       ansible.builtin.include_tasks: "{{ playbookdir }}/configure-open5gcore.yaml"
 
+    - name: Configure caddy for Open5GCore CLI
+      ansible.builtin.include_tasks: "{{ playbookdir }}/install-caddy.yaml"
+
     - name: export Variables as facts
       ansible.builtin.set_fact:
         n2_ip: "{{ n2_ip }}"

--- a/open5gcore_vm/code/one/cac/02_install/setup-open5gcore.yaml
+++ b/open5gcore_vm/code/one/cac/02_install/setup-open5gcore.yaml
@@ -30,6 +30,7 @@
     ##
     upf_xdp: "{{ one_open5gcore_vm_upf_xdp | default(false) }}"
     ue_count: "{{ one_open5gcore_vm_ue_count | default('20') }}"
+    dnn_mtu: 1406 #when GUEST_MTU == 1450
     apt_upgrade: false
     playbookdir: "{{ workspace }}/{{ component_type }}/code/one/cac/02_install/"
     license_crt: "{{ site_available_components.open5gcore_vm.license_crt }}"

--- a/open5gcore_vm/code/one/cac/02_install/templates/99-open5gcore.network.j2
+++ b/open5gcore_vm/code/one/cac/02_install/templates/99-open5gcore.network.j2
@@ -20,5 +20,5 @@ Destination={{ ue_subnet }}
 #Destination=10.45.1.0/24
 
 [Link]
-MTUBytes=1456
+MTUBytes={{ dnn_mtu }}
 RequiredForOnline=false

--- a/open5gcore_vm/code/one/cac/02_install/templates/add-test-ues.sh.j2
+++ b/open5gcore_vm/code/one/cac/02_install/templates/add-test-ues.sh.j2
@@ -9,6 +9,6 @@ open5gs-dbctl reset
 
 {% for i in range(ue_count|int) %}
 #open5gs-dbctl add_ue_with_slice {{ mcc }}{{ mnc }}{{ '%010d' % (msin|int + i) }} {{ ue_key }} {{ ue_opc }} {{ ue_apn }} 1 {{ s_nssai_sd }}
-/etc/open5gcore/sql/provision_user.sh -S {{ mcc }}{{ mnc }}{{ '%010d' % (msin|int + i) }} -k {{ ue_key }} -o {{ ue_opc }} -c 1 -u 0 -T {{ '1%010d' % (msin|int + i) }}
+/etc/open5gcore/sql/provision_user.sh -S {{ mcc }}{{ mnc }}{{ ('%0'+(12-mnc|length)|string +'d') % (msin|int + i) }} -k {{ ue_key }} -o {{ ue_opc }} -c 1 -u 0 -T {{ '1%010d' % (msin|int + i) }}
 {% endfor %}
 

--- a/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/smf.json.j2
+++ b/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/smf.json.j2
@@ -60,7 +60,7 @@
                 "version": 1,
                 "binaryFile": "modules/remote_command/remote_command.so",
                 "config": {
-                    "name": "NRF"
+                    "name": "SMF"
                 }
             },
             {

--- a/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/smf.json.j2
+++ b/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/smf.json.j2
@@ -90,7 +90,7 @@
                             "maxAttempt":3
                         }
                     },
-                    "mtu": 1456,
+                    "mtu": {{ dnn_mtu }},
                     "dnn":[
                         { "ignore": 1 , "name": "", "ipaddr": "", "slice": [{"sst": 1, "sd": "000001"}],"ipv4_allocation": [{"supi": "", "ipaddr": ""}, {"mac": "", "ipaddr": ""}], "dns": [""] },
                         { "name": "ims", "ipaddr": "10.45.3.0/24", "reserved_ip": ["10.45.3.254"], "dns": ["8.8.8.8"] },

--- a/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/sql/zz_test_ue.sql.j2
+++ b/open5gcore_vm/code/one/cac/02_install/templates/open5gcore/sql/zz_test_ue.sql.j2
@@ -1,7 +1,7 @@
 use udm_db;
 
 {% for i in range(ue_count|int) %}
--- open5gs-dbctl add_ue_with_slice {{ mcc }}{{ mnc }}{{ '%010d' % (msin|int + i) }} {{ ue_key }} {{ ue_opc }} {{ ue_apn }} 1 {{ s_nssai_sd }}
--- ./provision_user.sh -S {{ mcc }}{{ mnc }}{{ '%010d' % (msin|int + i) }} -k {{ ue_key }} -o {{ ue_opc }} -c 1 -u 0 -T {{ '1%010d' % (msin|int + i) }}
-INSERT INTO `supi` VALUES (0,"{{ mcc }}{{ mnc }}{{ '%010d' % (msin|int + i) }}",UNHEX("{{ ue_key }}"),0x8000,UNHEX("{{ ue_opc }}"),"000000000010",0,1,0);
+-- open5gs-dbctl add_ue_with_slice {{ mcc }}{{ mnc }}{{ ('%0'+(12-mnc|length)|string +'d') % (msin|int + i) }} {{ ue_key }} {{ ue_opc }} {{ ue_apn }} 1 {{ s_nssai_sd }}
+-- ./provision_user.sh -S {{ mcc }}{{ mnc }}{{ ('%0'+(12-mnc|length)|string +'d') % (msin|int + i) }} -k {{ ue_key }} -o {{ ue_opc }} -c 1 -u 0 -T {{ '1%010d' % (msin|int + i) }}
+INSERT INTO `supi` VALUES (0,"{{ mcc }}{{ mnc }}{{ ('%0'+(12-mnc|length)|string +'d') % (msin|int + i) }}",UNHEX("{{ ue_key }}"),0x8000,UNHEX("{{ ue_opc }}"),"000000000010",0,1,0);
 {% endfor %}

--- a/open5gcore_vm/result_templates/ok_result.md.j2
+++ b/open5gcore_vm/result_templates/ok_result.md.j2
@@ -1,8 +1,10 @@
 # {{ tn_id }}-{{ entity_name}}
 
-[Open5Gcore](https://www.open5gcore.org/), an 5G SA core network implementation, has been successfully deployed as a VM as part of the Trial Network **{{ tn_id }}**.
+The component `{{ tn_id }}-{{ entity_name}}` has been succesfully created.
 
-<img src="https://cdn0.scrvt.com/fokus/d9859d6f8b785685/4d3f99755ad3/v/96292ff212e8/NGNI_logo_open5gcore_02.jpg" />
+<img src="https://cdn0.scrvt.com/fokus/736fbda3b8aaa2ed/8f84ea246d5c/v/5a67a1cf6669/NGNI_logo_open5gcore.jpg" />
+
+[Open5Gcore](https://www.open5gcore.org/), an 5G SA core network implementation, has been successfully deployed as a VM as part of the Trial Network **{{ tn_id }}**.
 
 Below is a summary of the components that have been deployed:
 

--- a/open5gcore_vm/result_templates/ok_result.md.j2
+++ b/open5gcore_vm/result_templates/ok_result.md.j2
@@ -14,11 +14,10 @@ Below is a summary of the components that have been deployed:
 * UPF - User Plane Function
 * AUSF - Authentication Server Function
 * UDM - Unified Data Management
-* UDR - Unified Data Repository
 * PCF - Policy and Charging Function
 
 Current versions:
-- Open5GCore `v9.0.x`
+- Open5GCore `v9.1.0`
 - Ubuntu 22.04
 
 ## Important information


### PR DESCRIPTION
This PR adds 
- a caddy proxy to expose the open5gcore webCLI to experimenters
- fixes the MTU of the UE subnet to fit into the GUEST_MTU default of 1450
- create a return route for the UE-subnet on the bastion to the core-vm which allowes internet access on connected UEs