### PR TITLE
open5gs_vm: UE-Subnet routing on bastion

### DIFF
--- a/open5gs_vm/changelog.md
+++ b/open5gs_vm/changelog.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 ### Added
 - Initial version of the Open5GS VM component.
+- Automatically configure a route on the `bastion` for the `ue_subnet` back to the core-VM
 
 
 <!-- Change latest version value at every release -->

--- a/open5gs_vm/code/any/cac/enable_routing_bastion.yaml
+++ b/open5gs_vm/code/any/cac/enable_routing_bastion.yaml
@@ -1,0 +1,8 @@
+- name: Add routes in bastion
+  vars:
+    o5gs_tn_vxlan_ip: "{{ hostvars['localhost']['ips'][hostvars['localhost']['access_vnet_id']]}}"
+  ansible.builtin.shell: "ip route add {{ item }}"
+  with_items:
+    - "{{ one_open5gs_vm_ue_subnet }} via {{ o5gs_tn_vxlan_ip }}"
+  become: yes
+

--- a/open5gs_vm/code/any/cac/enable_routing_bastion.yaml
+++ b/open5gs_vm/code/any/cac/enable_routing_bastion.yaml
@@ -1,7 +1,7 @@
 - name: Add routes in bastion
   vars:
     o5gs_tn_vxlan_ip: "{{ hostvars['localhost']['ips'][hostvars['localhost']['access_vnet_id']]}}"
-  ansible.builtin.shell: "ip route add {{ item }}"
+  ansible.builtin.shell: "ip route add {{ item }} || ip route change {{ item }}"
   with_items:
     - "{{ one_open5gs_vm_ue_subnet }} via {{ o5gs_tn_vxlan_ip }}"
   become: yes

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -54,6 +54,12 @@
             if one_open5gs_vm_internal_vnet | length > 2 else ''
           }}
 
+    - name: Add the bastion to Ansible Inventory
+      ansible.builtin.add_host:
+        hostname: "bastion"
+        ansible_host: "{{ bastion_ip }}"
+        ansible_user: "jenkins"
+
     - name: Add new VM to Ansible Inventory
       ansible.builtin.add_host:
         hostname: "open5gs_vm"
@@ -110,6 +116,15 @@
     - name: Install Open5GS and MongoDB
       ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/{{ hostvars['localhost']['site_hypervisor'] }}/cac/02_install/install-open5gs.yml"
 
+- name: "STAGE 3: Apply CaC to deploy the component - STEP 2 (bastion)"
+  hosts: "bastion"
+  gather_facts: false
+  tasks:
+    - name: Load enviromental variables from different sources inside the component
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+
+    - name: Enable routing path in Bastion
+      ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_bastion.yaml"
 
 - name: "STAGE 4: Publish execution results"
   hosts: localhost


### PR DESCRIPTION
This PR changes the Open5gs_vm component to create a return route for the UE-subnet on the bastion to the core-vm which allowed internet access on connected UEs