### PR TITLE
Berlin RAN component

### DIFF
--- a/berlin_ran/.tnlcm/public.yaml
+++ b/berlin_ran/.tnlcm/public.yaml
@@ -1,0 +1,105 @@
+######################################################
+##
+## Component public variables
+##
+## Variables accesible to the experimenter.
+##
+## They are contained inside 3 global variables
+## with all required info:
+##
+##   1. metadata: General information like mantainers,
+##      component dependencies and allowed platforms
+##
+##   2. input: Customizable variables for each
+##      deployment to be filled by the experimenter
+##      or the TNLCM
+##
+##   3. output: Values sent to the TNLCM callback to
+##      keep track of the TN deployments
+##
+######################################################
+
+
+####################################
+## Component metadata
+####################################
+metadata:
+  maintainers:
+    - Bjoern Riemer <bjoern.riemer@fokus.fraunhofer.de>
+  short_description: Enables the capability of using physical RAN in a Trial Network.
+  long_description: |
+    This component enables the integration of RAN physical equipment located at FOKUS with a 5G core deployed in the Trial Network.
+    It is done by enabling the necessary routing path through the use of the element called ‘Route Manager’ (already deployed in the site). 
+    The configuration exposed by this component should be synchronized with the 5G core and the UE to be used in conjunction:
+    - `mcc`: "999"
+    - `mnc`: "38"
+    - `apn`: "internet"
+    - `tac`: 122
+    - `s_nssai_sst`: 1
+    - `s_nssai_sd`: ""
+    - `amf_ip`: "10.10.11.200"
+    - `upf_ip`: "10.10.11.201"
+    NOTE: Currently this component is only available in the site "fokus".
+  hypervisors: [one]
+  destroy_script: true
+
+####################################
+## Component input
+####################################
+
+input:
+  berlin_ran_one_oneKE:
+    description: Name of the oneKE cluster to route Nokia traffic.
+    type: "oneKE"
+    required_when: false
+  berlin_ran_one_reservation_time:
+    description: Time in minutes for the RAN equipment reservation
+    type: int
+    default_value: 60
+    required_when: true
+  berlin_ran_one_linked_open5g:
+    description: Name of a previously deployed 5G-core instance. Defines the 5G SA core the gNB will try to connect
+    type: open5gs or open5gs_vm or open5gcore_vm
+    required_when: false
+
+
+####################################
+## Component output
+####################################
+output:
+  metadata_dict: # Dictionary with multiple parameters about the berlin_ran component
+    reservation_time: input.berlin_ran_one_reservation_time
+    oneKE: input.berlin_ran_one_oneKE
+    ran_subnet: site_variables.subnet
+    #cp_ip: site_variables.cp_ip
+    #up_ip: site_variables.up_ip
+    core_network: site_variables.core_network
+    route_manager_ip1: site_variables.route_manager_ip1
+    #route_manager_ip2: site_variables.route_manager_ip2
+    mcc: site_variables.mcc
+    mnc: site_variables.mnc
+    tac: site_variables.tac
+    s_nssai_sst: site_variables.s_nssai_sst
+    s_nssai_sd: site_variables.s_nssai_sd
+    amf_ip: site_variables.amf_ip
+    upf_ip: site_variables.upf_ip
+
+
+####################################
+## Site-specific variables
+####################################
+site_variables:
+  #cp_ip: Address of Nokia Airscale
+  # up_ip:
+  subnet: Subnet used for the RAN N2 and N3 interfaces.
+  core_network: Subnetwork (CIDR) of the private subnet of the input.berlin_ran_one_oneKE. Will be autocompleted in the future
+  route_manager_ip1: First IP address of the route manager that will enable routing between Nokia Airscale and 5G Core.
+  #route_manager_ip2:
+  mcc:   # Unused, will complete other components dependencies in the future
+  mnc:   # Unused, will complete other components dependencies in the future
+  tac:   # Unused, will complete other components dependencies in the future
+  s_nssai_sst:   # Unused, will complete other components dependencies in the future
+  s_nssai_sd:    # Unused, will complete other components dependencies in the future
+  amf_ip:    # Unused, will complete other components dependencies in the future
+  upf_ip:    # Unused, will complete other components dependencies in the future
+  token: Token to authorize the route-manager API

--- a/berlin_ran/.tnlcm/public.yaml
+++ b/berlin_ran/.tnlcm/public.yaml
@@ -49,7 +49,7 @@ metadata:
 
 input:
   berlin_ran_one_oneKE:
-    description: Name of the oneKE cluster to route Nokia traffic.
+    description: Name of the oneKE cluster to route RAN traffic.
     type: "oneKE"
     required_when: false
   berlin_ran_one_reservation_time:
@@ -89,11 +89,11 @@ output:
 ## Site-specific variables
 ####################################
 site_variables:
-  #cp_ip: Address of Nokia Airscale
-  # up_ip:
+  #cp_ip: Address of n2 RAN interface
+  # up_ip: Address on n3 RAN interface
   subnet: Subnet used for the RAN N2 and N3 interfaces.
   core_network: Subnetwork (CIDR) of the private subnet of the input.berlin_ran_one_oneKE. Will be autocompleted in the future
-  route_manager_ip1: First IP address of the route manager that will enable routing between Nokia Airscale and 5G Core.
+  route_manager_ip1: First IP address of the route manager that will enable routing between RAN and 5G Core.
   #route_manager_ip2:
   mcc:   # Unused, will complete other components dependencies in the future
   mnc:   # Unused, will complete other components dependencies in the future

--- a/berlin_ran/.tnlcm/public.yaml
+++ b/berlin_ran/.tnlcm/public.yaml
@@ -70,6 +70,7 @@ output:
   metadata_dict: # Dictionary with multiple parameters about the berlin_ran component
     reservation_time: input.berlin_ran_one_reservation_time
     oneKE: input.berlin_ran_one_oneKE
+    linked_open5g: input.berlin_ran_one_linked_open5g
     ran_subnet: site_variables.subnet
     #cp_ip: site_variables.cp_ip
     #up_ip: site_variables.up_ip

--- a/berlin_ran/.tnlcm/public.yaml
+++ b/berlin_ran/.tnlcm/public.yaml
@@ -50,7 +50,7 @@ metadata:
 input:
   berlin_ran_one_oneKE:
     description: Name of the oneKE cluster to route RAN traffic.
-    type: "oneKE"
+    type: "string"
     required_when: false
   berlin_ran_one_reservation_time:
     description: Time in minutes for the RAN equipment reservation

--- a/berlin_ran/.tnlcm/public.yaml
+++ b/berlin_ran/.tnlcm/public.yaml
@@ -50,7 +50,7 @@ metadata:
 input:
   berlin_ran_one_oneKE:
     description: Name of the oneKE cluster to route RAN traffic.
-    type: "string"
+    type: "oneKE"
     required_when: false
   berlin_ran_one_reservation_time:
     description: Time in minutes for the RAN equipment reservation

--- a/berlin_ran/README.md
+++ b/berlin_ran/README.md
@@ -1,0 +1,16 @@
+# RAN ACCESS for Berlin Platform
+
+Component to integrate the RAN physical equipment with 5G cores deployed inside Trial Networks.
+It is done by enabling the necessary routing path through the use of the element called ‘Route Manager’ (already deployed in the site). 
+The configuration exposed by this component should be synchronized with the 5G core and the UE to be used in conjunction:
+- `mcc`: "999" 
+- `mnc`: "38"
+- `apn`: "internet"
+- `tac`: 122
+- `s_nssai_sst`: 1
+- `s_nssai_sd`: ""
+- `amf_ip`: "10.10.11.200"
+- `upf_ip`: "10.10.11.201"
+
+> [!NOTE]  
+> Currently this component is only available in the site "fokus".

--- a/berlin_ran/changelog.md
+++ b/berlin_ran/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [v0.5.0]
 ### Added
 - Initial release of `berlin_ran` from `nokia_radio`
 

--- a/berlin_ran/changelog.md
+++ b/berlin_ran/changelog.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## [unreleased]
+### Added
+- Initial release of `berlin_ran` from `nokia_radio`
+
+
+<!-- Change latest version value at every release -->
+[unreleased]: https://github.com/6G-SANDBOX/6G-Library/compare/v0.3.0...unreleased
+[v0.3.0]: https://github.com/6G-SANDBOX/6G-Library/compare/v0.2.1...v0.3.0
+[v0.2.0]: https://github.com/6G-SANDBOX/6G-Library/compare/v0.1.0...v0.2.0
+
+<!-- FIELDS PER VERSION -->
+<!--
+### Added
+
+- New features
+
+### Changed
+
+- Changes in existing functionality
+
+### Deprecated
+
+- Soon-to-be removed features
+
+### Removed
+
+- Removed features
+
+### Fixed
+
+- Bug fixes
+
+### Security
+
+- Vulnerability warnings
+-->

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -37,3 +37,4 @@
         - "{{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
         - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
       when: o5gcore_ip | length > 0
+      ## TODO: check if core_network range is already reachable (via different network...)

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -5,16 +5,17 @@
     #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
   block:
     - name: debug vars
-      var:
-        - oneKE_vnf0_ip
-        - o5gcore_ip
-      msg:
-        - "oneKE"
-        - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"
-        - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
-        - "5g-core VM"
-        - "ip r a {{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
-        - "ip r a {{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+      debug:
+        var:
+          - oneKE_vnf0_ip
+          - o5gcore_ip
+        msg:
+          - "oneKE"
+          - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"
+          - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+          - "5g-core VM"
+          - "ip r a {{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
+          - "ip r a {{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
       when: debug
 
     - name: add routes for oneKE

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -4,11 +4,15 @@
     o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 else '' }}"
     #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
   block:
-    - name: debug vars
+    - name: debug variables
       debug:
         var:
           - oneKE_vnf0_ip
           - o5gcore_ip
+      when: debug
+
+    - name: debug inputs
+      debug:
         msg:
           - "oneKE"
           - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -1,7 +1,7 @@
 - name: Add routes in bastion
   vars:
     oneKE_vnf0_ip: "{{ hostvars['localhost']['node_ips'].get('vnf_0','') }}"
-    o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 else '' }}"
+    o5gcore_ip: "{{ hostvars['localhost']['core_ips'].get(hostvars['localhost']['tn_vxlan_id'],'') if hostvars['localhost']['core_ips'] | length >=1 else '' }}"
     #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
   block:
     - name: debug variables

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -1,7 +1,7 @@
 - name: Add routes in bastion
   vars:
     oneKE_vnf0_ip: "{{ hostvars['localhost']['node_ips'].get('vnf_0','') }}"
-    o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 esle '' }}"
+    o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 else '' }}"
     #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
   block:
     - name: add routes for oneKE

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -1,0 +1,21 @@
+- name: Add routes in bastion
+  vars:
+    oneKE_vnf0_ip: "{{ hostvars['localhost']['node_ips'].get('vnf_0','') }}"
+    o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 esle '' }}"
+    #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
+  block:
+    - name: add routes for oneKE
+      become: yes
+      ansible.builtin.shell: "ip route add {{ item }}"
+      with_items:
+        - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"
+        - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+      when: oneKE_vnf0_ip|length > 0
+
+    - name: add route for 5g-core VM
+      become: yes
+      ansible.builtin.shell: "ip route add {{ item }}"
+      with_items:
+        - "{{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
+        - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+      when: o5gcore_ip | length > 0

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -4,6 +4,19 @@
     o5gcore_ip: "{{ hostvars['localhost']['core_ips'][0]['ip'] if hostvars['localhost']['core_ips'] | length >=1 else '' }}"
     #next_hop_to_core: "{{ o5gcore_ip if o5gcore_ip|length>0 elif oneKE_vnf0_ip if oneKE_vnf0_ip|length>0 else '' }}"
   block:
+    - name: debug vars
+      var:
+        - oneKE_vnf0_ip
+        - o5gcore_ip
+      msg:
+        - "oneKE"
+        - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"
+        - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+        - "5g-core VM"
+        - "ip r a {{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
+        - "ip r a {{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
+      when: debug
+
     - name: add routes for oneKE
       become: yes
       ansible.builtin.shell: "ip route add {{ item }}"

--- a/berlin_ran/code/any/cac/enable_routing_bastion.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_bastion.yaml
@@ -24,7 +24,7 @@
 
     - name: add routes for oneKE
       become: yes
-      ansible.builtin.shell: "ip route add {{ item }}"
+      ansible.builtin.shell: "ip route add {{ item }} || ip r c {{ item }}"
       with_items:
         - "{{ site_available_components.berlin_ran.core_network }} via {{ oneKE_vnf0_ip }}"
         - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"
@@ -32,7 +32,7 @@
 
     - name: add route for 5g-core VM
       become: yes
-      ansible.builtin.shell: "ip route add {{ item }}"
+      ansible.builtin.shell: "ip route add {{ item }} || ip r c {{ item }}"
       with_items:
         - "{{ site_available_components.berlin_ran.core_network }} via {{ o5gcore_ip }}"
         - "{{ site_available_components.berlin_ran.subnet }} via {{ site_available_components.berlin_ran.route_manager_ip1 }}"

--- a/berlin_ran/code/any/cac/enable_routing_manager.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_manager.yaml
@@ -1,0 +1,31 @@
+#- name: Execute manage_route script in Router Manager
+#  ansible.builtin.shell:
+#  args:
+#    executable: /bin/bash
+#    cmd: "nohup /root/route-manager.sh {{ tn_id }} {{ site_available_components.berlin_ran.core_network }} {{ hostvars['localhost']['bastion_ip'] }} {{ berlin_ran_one_reservation_time }} > /tmp/route-manager.log 2>&1 &" 
+#  async: 0
+#  poll: 0
+
+- name: enable route via route-manager-api
+  ansible.builtin.uri:
+    url: http://{{ route_manager_ip }}:8172/routes
+    method: POST
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ site_available_components.berlin_ran.token }}"
+    body:
+      - destination: "{{ site_available_components.berlin_ran.core_network }}"
+        gateway: "{{ hostvars['localhost']['bastion_ip'] }}"
+        #create_at: ""
+        #delete_at: "{{ ansible_date_time.minute | int +berlin_ran_one_reservation_time | int }}"
+
+#curl -X 'POST' \
+#  'http://192.168.248.117:8172/routes' \
+#  -H 'accept: application/json' \
+#  -H 'Authorization: Bearer xx' \
+#  -H 'Content-Type: application/json' \
+#  -d '{
+#  "destination": "10.10.11.0/24",
+#  "gateway": "192.168.248.111"
+#}'
+

--- a/berlin_ran/code/any/cac/enable_routing_manager.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_manager.yaml
@@ -6,6 +6,20 @@
 #  async: 0
 #  poll: 0
 
+- name: first delte the old route via route-manager-api
+  ansible.builtin.uri:
+    url: http://{{ site_available_components.berlin_ran.route_manager_ip1 }}:8172/routes
+    method: DELETE
+    body_format: json
+    status_code: [200, 500, 422]
+    headers:
+      Authorization: "Bearer {{ site_available_components.berlin_ran.token }}"
+    body: >-
+          {
+            'destination': "{{ site_available_components.berlin_ran.core_network }}",
+            'gateway': "{{ hostvars['localhost']['bastion_ip'] }}"
+          }
+
 - name: enable route via route-manager-api
   ansible.builtin.uri:
     url: http://{{ site_available_components.berlin_ran.route_manager_ip1 }}:8172/routes

--- a/berlin_ran/code/any/cac/enable_routing_manager.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_manager.yaml
@@ -8,7 +8,7 @@
 
 - name: enable route via route-manager-api
   ansible.builtin.uri:
-    url: http://{{ route_manager_ip }}:8172/routes
+    url: http://{{ site_available_components.berlin_ran.route_manager_ip1 }}:8172/routes
     method: POST
     body_format: json
     headers:

--- a/berlin_ran/code/any/cac/enable_routing_manager.yaml
+++ b/berlin_ran/code/any/cac/enable_routing_manager.yaml
@@ -13,11 +13,11 @@
     body_format: json
     headers:
       Authorization: "Bearer {{ site_available_components.berlin_ran.token }}"
-    body:
-      - destination: "{{ site_available_components.berlin_ran.core_network }}"
-        gateway: "{{ hostvars['localhost']['bastion_ip'] }}"
-        #create_at: ""
-        #delete_at: "{{ ansible_date_time.minute | int +berlin_ran_one_reservation_time | int }}"
+    body: >-
+          {
+            'destination': "{{ site_available_components.berlin_ran.core_network }}",
+            'gateway': "{{ hostvars['localhost']['bastion_ip'] }}"
+          }
 
 #curl -X 'POST' \
 #  'http://192.168.248.117:8172/routes' \

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -67,7 +67,7 @@
   tasks:
     - name: Define Nokia metadata dictionary
       ansible.builtin.set_fact:
-        nokia_metadata_dict: >-
+        berlin_ran_metadata_dict: >-
           {
             'reservation_time': '{{ berlin_ran_one_reservation_time }}',
             'oneKE': '{{ berlin_ran_one_oneKE }}',
@@ -89,10 +89,10 @@
       vars:
         custom_outputs:
           - key: "{{ entity_name }}-metadata"
-            value: "{{ nokia_metadata_dict }}"
+            value: "{{ berlin_ran_metadata_dict }}"
 
     - name: Publish execution results to TNLCM
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/publish_ok_results.yaml"
       vars:
         output:
-          metadata_dict: "{{ nokia_metadata_dict | b64encode }}"
+          metadata_dict: "{{ berlin_ran_metadata_dict | b64encode }}"

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -1,0 +1,98 @@
+---
+- name: "STAGE 1: Prepare to access a previous target component"
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Load enviromental variables from different sources
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+
+    - name: Prepare terraform working directory
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/terraform_workdir.yaml"
+
+    - name: Retrieve terraform outputs
+      ansible.builtin.shell:
+      args:
+        chdir: "{{ workspace }}/.terraform/"
+        cmd: "set -o pipefail && terraform output --json | jq 'with_entries(.value |= .value)'"
+        executable: /bin/bash
+      register: terraform_outputs
+      changed_when: false
+
+    - name: Set Terraform outputs as playbook facts
+      ansible.builtin.set_fact:
+        bastion_ip: "{{ (terraform_outputs.stdout | from_json)['tn_bastion-ips'][site_networks_id.default | string] }}"
+        node_ips: "{{ (terraform_outputs.stdout | from_json)[berlin_ran_one_oneKE + '-node_ips'] | default('{}') }}"
+        core_ips: "{{ (terraform_outputs.stdout | from_json)[berlin_ran_one_linked_open5g + '-ips'] | dict2items(key_name='id', value_name='ip') | default('[]') }}"
+
+    - name: Add Route Manager to Ansible Inventory
+      ansible.builtin.add_host:
+        hostname: "routemanager"
+        ansible_host: "{{ site_available_components.berlin_ran.route_manager_ip1 }}"
+        ansible_user: "root"
+        ansible_ssh_private_key_file: "/var/lib/jenkins/.ssh/id_ed25519"
+
+    - name: Add the bastion to Ansible Inventory
+      ansible.builtin.add_host:
+        hostname: "bastion"
+        ansible_host: "{{ bastion_ip }}"
+        ansible_user: "jenkins"
+
+
+- name: "STAGE 2: Apply IaC to deploy the component - STEP 1"
+  hosts: "routemanager"
+  gather_facts: false
+  tasks:
+    - name: Load enviromental variables from different sources inside the component
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+
+    - name: Enable routing path in Route Manager
+      ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_manager.yaml"
+
+- name: "STAGE 2: Apply IaC to deploy the component - STEP 2"
+  hosts: "bastion"
+  gather_facts: false
+  tasks:
+    - name: Load enviromental variables from different sources inside the component
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+
+    - name: Enable routing path in Bastion
+      ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_bastion.yaml"
+
+
+- name: "STAGE 3: Publish execution results"
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Define Nokia metadata dictionary
+      ansible.builtin.set_fact:
+        nokia_metadata_dict: >-
+          {
+            'reservation_time': '{{ berlin_ran_one_reservation_time }}',
+            'oneKE': '{{ berlin_ran_one_oneKE }}',
+            'linked_open5g': '{{ berlin_ran_one_linked_open5g }}'
+            'cp_ip': '',
+            'subnet': '{{ site_available_components.berlin_ran.subnet }}''
+            'core_network': '{{ site_available_components.berlin_ran.core_network }}',
+            'route_manager_ip1': '{{ site_available_components.berlin_ran.route_manager_ip1 }}',
+            'mcc': '{{ site_available_components.berlin_ran.mcc }}',
+            'mnc': '{{ site_available_components.berlin_ran.mnc }}',
+            'tac': '{{ site_available_components.berlin_ran.tac }}',
+            's_nssai_sst': '{{ site_available_components.berlin_ran.s_nssai_sst }}',
+            's_nssai_sd': '{{ site_available_components.berlin_ran.s_nssai_sd }}',
+            'amf_ip': '{{ site_available_components.berlin_ran.amf_ip }}',
+            'upf_ip': '{{ site_available_components.berlin_ran.upf_ip }}'
+          }
+    - name: Publish Nokia metadata as terraform outputs"
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/custom_tf_outputs.yaml"
+      vars:
+        custom_outputs:
+          - key: "{{ entity_name }}-metadata"
+            value: "{{ nokia_metadata_dict }}"
+
+    - name: Publish execution results to TNLCM
+      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/publish_ok_results.yaml"
+      vars:
+        output:
+          metadata_dict: "{{ nokia_metadata_dict | b64encode }}"

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -25,7 +25,8 @@
       ansible.builtin.set_fact:
         bastion_ip: "{{ terraform_output['tn_bastion-ips'][site_networks_id.default | string] }}"
         node_ips: "{{ terraform_output.get(berlin_ran_one_oneKE|default('NONE') + '-node_ips',{}) }}"
-        core_ips: "{{ terraform_output[berlin_ran_one_linked_open5g|default('NONE') + '-ips'] | dict2items(key_name='id', value_name='ip') | default('[]') }}"
+        core_ips: "{{ terraform_output[berlin_ran_one_linked_open5g|default('NONE') + '-ips'] | default('{}') }}"
+        tn_vxlan_id: "{{ terraform_output['tn_vxlan-id'] | string }}"
 
     - name: Add Route Manager to Ansible Inventory
       ansible.builtin.add_host:

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -77,9 +77,9 @@
           {
             'reservation_time': '{{ berlin_ran_one_reservation_time }}',
             'oneKE': '{{ berlin_ran_one_oneKE | default('') }}',
-            'linked_open5g': '{{ berlin_ran_one_linked_open5g | default('') }}'
+            'linked_open5g': '{{ berlin_ran_one_linked_open5g | default('') }}',
             'cp_ip': '',
-            'subnet': '{{ site_available_components.berlin_ran.subnet }}''
+            'subnet': '{{ site_available_components.berlin_ran.subnet }}',
             'core_network': '{{ site_available_components.berlin_ran.core_network }}',
             'route_manager_ip1': '{{ site_available_components.berlin_ran.route_manager_ip1 }}',
             'mcc': '{{ site_available_components.berlin_ran.mcc }}',

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -20,10 +20,12 @@
       changed_when: false
 
     - name: Set Terraform outputs as playbook facts
+      vars:
+        terraform_output: "{{terraform_outputs.stdout | from_json}}"
       ansible.builtin.set_fact:
-        bastion_ip: "{{ (terraform_outputs.stdout | from_json)['tn_bastion-ips'][site_networks_id.default | string] }}"
-        node_ips: "{{ (terraform_outputs.stdout | from_json)[berlin_ran_one_oneKE + '-node_ips'] | default('{}') }}"
-        core_ips: "{{ (terraform_outputs.stdout | from_json)[berlin_ran_one_linked_open5g + '-ips'] | dict2items(key_name='id', value_name='ip') | default('[]') }}"
+        bastion_ip: "{{ terraform_output['tn_bastion-ips'][site_networks_id.default | string] }}"
+        node_ips: "{{ terraform_output.get(berlin_ran_one_oneKE|default('NONE') + '-node_ips',{}) }}"
+        core_ips: "{{ terraform_output[berlin_ran_one_linked_open5g|default('NONE') + '-ips'] | dict2items(key_name='id', value_name='ip') | default('[]') }}"
 
     - name: Add Route Manager to Ansible Inventory
       ansible.builtin.add_host:

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -78,7 +78,6 @@
             'reservation_time': '{{ berlin_ran_one_reservation_time }}',
             'oneKE': '{{ berlin_ran_one_oneKE | default('') }}',
             'linked_open5g': '{{ berlin_ran_one_linked_open5g | default('') }}',
-            'cp_ip': '',
             'subnet': '{{ site_available_components.berlin_ran.subnet }}',
             'core_network': '{{ site_available_components.berlin_ran.core_network }}',
             'route_manager_ip1': '{{ site_available_components.berlin_ran.route_manager_ip1 }}',

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -65,7 +65,7 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: Define Nokia metadata dictionary
+    - name: Define metadata dictionary
       ansible.builtin.set_fact:
         berlin_ran_metadata_dict: >-
           {
@@ -84,7 +84,7 @@
             'amf_ip': '{{ site_available_components.berlin_ran.amf_ip }}',
             'upf_ip': '{{ site_available_components.berlin_ran.upf_ip }}'
           }
-    - name: Publish Nokia metadata as terraform outputs"
+    - name: Publish metadata as terraform outputs"
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/custom_tf_outputs.yaml"
       vars:
         custom_outputs:

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -40,16 +40,19 @@
         ansible_host: "{{ bastion_ip }}"
         ansible_user: "jenkins"
 
-
-- name: "STAGE 2: Apply IaC to deploy the component - STEP 1"
-  hosts: "routemanager"
-  gather_facts: false
-  tasks:
-    - name: Load enviromental variables from different sources inside the component
-      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
-
-    - name: Enable routing path in Route Manager
+    - name: Enable routing path in Route Manager (via REST api)
       ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_manager.yaml"
+
+
+#- name: "STAGE 2: Apply IaC to deploy the component - STEP 1"
+#  hosts: "routemanager"
+#  gather_facts: false
+#  tasks:
+#    - name: Load enviromental variables from different sources inside the component
+#      ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
+#
+#    - name: Enable routing path in Route Manager
+#      ansible.builtin.include_tasks: "{{ workspace }}/{{ component_type }}/code/any/cac/enable_routing_manager.yaml"
 
 - name: "STAGE 2: Apply IaC to deploy the component - STEP 2"
   hosts: "bastion"

--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -76,8 +76,8 @@
         berlin_ran_metadata_dict: >-
           {
             'reservation_time': '{{ berlin_ran_one_reservation_time }}',
-            'oneKE': '{{ berlin_ran_one_oneKE }}',
-            'linked_open5g': '{{ berlin_ran_one_linked_open5g }}'
+            'oneKE': '{{ berlin_ran_one_oneKE | default('') }}',
+            'linked_open5g': '{{ berlin_ran_one_linked_open5g | default('') }}'
             'cp_ip': '',
             'subnet': '{{ site_available_components.berlin_ran.subnet }}''
             'core_network': '{{ site_available_components.berlin_ran.core_network }}',

--- a/berlin_ran/result_templates/fail_result.md.j2
+++ b/berlin_ran/result_templates/fail_result.md.j2
@@ -1,0 +1,5 @@
+There was an error. Detailed info:
+
+```
+{{ terraform_apply.stderr }}
+```

--- a/berlin_ran/result_templates/ok_result.md.j2
+++ b/berlin_ran/result_templates/ok_result.md.j2
@@ -1,0 +1,16 @@
+# {{ tn_id }}-{{ entity_name }}
+
+The component `{{ tn_id }}-{{ entity_name }}` has been succesfully created.
+The RAN Equipment ( {{ site_available_components.berlin_ran.cp_ip }} ) is now available in your Trial Network.
+
+## Important information:
+
+This component will be available for `{{ berlin_ran_one_reservation_time }}` minutes from now. The Route Manager used for enabling the routing path is `{{ site_available_components.berlin_ran.route_manager_ip1 }}`.
+
+- **PLMN ID (MCC)**: `{{ site_available_components.berlin_ran.mcc  }}`
+- **PLMN ID (MNC)**: `{{ site_available_components.berlin_ran.mnc }}`
+- **TAC**: `{{ site_available_components.berlin_ran.tac  }}`
+- **S-NSSAI (SST)**: `{{ site_available_components.berlin_ran.s_nssai_sst }}`
+- **S-NSSAI (SD)**: `{{ site_available_components.berlin_ran.s_nssai_sd }}`
+- **AMF IP**: `{{ site_available_components.berlin_ran.amf_ip }}`
+- **UPF IP**: `{{ site_available_components.berlin_ran.upf_ip }}`

--- a/berlin_ran/result_templates/ok_result.md.j2
+++ b/berlin_ran/result_templates/ok_result.md.j2
@@ -1,7 +1,7 @@
 # {{ tn_id }}-{{ entity_name }}
 
 The component `{{ tn_id }}-{{ entity_name }}` has been succesfully created.
-The RAN Equipment ( {{ site_available_components.berlin_ran.cp_ip }} ) is now available in your Trial Network.
+The RAN Equipment ( {{ site_available_components.berlin_ran.cp_ip |default('') }} ) is now available in your Trial Network.
 
 ## Important information:
 

--- a/berlin_ran/sample_input_file.yaml
+++ b/berlin_ran/sample_input_file.yaml
@@ -1,0 +1,4 @@
+# THIS IS AN INPUT FILE EXAMPLE. Values may not be valid for your enviroment
+
+# berlin_ran_one_oneKE: ""
+# berlin_ran_one_reservation_time: 180

--- a/berlin_ran/variables/any/private.yaml
+++ b/berlin_ran/variables/any/private.yaml
@@ -1,0 +1,9 @@
+######################################################
+##
+## Component private variables
+##
+## Variables required for the deployment
+## and their default value.
+## Some of them are modifiable through input variables
+##
+######################################################

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - New component `upf_p4_sw`
 - New component `open5gs_vm`
 - New component `open5gcore_vm`
+- New component `berlin_ran`
 
 ### Changed
 - Variable `one_bastion_wireguard_allowedips` promoted as public and user-configurable in components `tn_bastion` and `tn_init`


### PR DESCRIPTION
This PR adds a `berlin_ran` component which uses the Route-Manager to enable routing to conect the existing RAN in the Berlin platform to the TN-network and the 5g-core (open5gs_vm or open5gcore_vm or open5gs_oneKE)