### PR TITLE
Hotfix/open5gs vm duplicate ue ip

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## unreleased
+### Fixed
+ - Component `open5gs_vm` remove hardcoded ip (10.45.0.1) from the `ogstun` interface (#99)
 
 ## [v0.4.0]
 ### Added

--- a/open5gs_vm/changelog.md
+++ b/open5gs_vm/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+### Fixed
+ - Remove hardcoded ip (10.45.0.1) from the `ogstun` interface
+
 ## v0.4.0
 ### Added
 - Initial release of `open5gs_vm` component to the 6G-Library. 

--- a/open5gs_vm/code/one/cac/02_install/templates/99-open5gs.network.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/99-open5gs.network.j2
@@ -1,9 +1,6 @@
 [Match]
 Name=ogstun
 
-[Network]
-Address=10.45.0.1/32
-
 ## DNN default
 [Route]
 Gateway=0.0.0.0


### PR DESCRIPTION
Remove the hardcoded IP from ogstun interface as this ip is also assigned to the first UE which then creates a duplicate IP addess inside the 5G data plane which breaks traffic forwarding.