### PR TITLE
Hotfix/o5gc rp filter redirects

### DIFF
--- a/berlin_ran/sample_tnlcm_descriptor.yaml
+++ b/berlin_ran/sample_tnlcm_descriptor.yaml
@@ -29,9 +29,9 @@ trial_network:
       one_open5gcore_vm_mcc: "999"
       one_open5gcore_vm_mnc: "38"
       one_open5gcore_vm_msin: "0000000001"
-      one_open5gcore_vm_key: "465B5CE8B199B49FAA5F0A2EE238A6BC"
-      one_open5gcore_vm_opc: "E8ED289DEBA952E4283B54E88E6183CA"
-      one_open5gcore_vm_apn: "internet"
+      #one_open5gcore_vm_key: "465B5CE8B199B49FAA5F0A2EE238A6BC" # Default value
+      #one_open5gcore_vm_opc: "E8ED289DEBA952E4283B54E88E6183CA" # Default value
+      #one_open5gcore_vm_apn: "internet" # Default value
       one_open5gcore_vm_tac: 122
       one_open5gcore_vm_s_nssai_sst: 1
       one_open5gcore_vm_s_nssai_sd: "000001"

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 ### Fixed
 - Component `ks8500_runner` updated to add firewall exceptions for `loadcore` and `ixchariot` middlewares.
 - All `.tnlcm/public.yaml` files now fit the LLM requirements as suggested in issue #128
+- remove the transmission of icmp-reirect messages from the UPF of `open5gcore_vm` and `open5gs_vm` component
 ### Deprecated
 - Multiple redundant variables removed from `ueransim`. **ue** mode now autocompletes its variables directly from the 5G core used by the *gNB*.
 

--- a/open5gcore_vm/changelog.md
+++ b/open5gcore_vm/changelog.md
@@ -5,6 +5,8 @@
 - Output dictionary `metadata` renamed to `5gcore_metadata`.
 - Variable `one_open5gcore_vm_external_vnet` is now optional with `tn_vxlan` by default.
 - Variable `one_open5gcore_vm_internal_vnet` is now mandatory.
+### Fixed
+- disbale sending of icmp redirect messages for the UPF
 
 
 ## v0.5.0

--- a/open5gcore_vm/code/one/cac/02_install/files/sysctl_20-5g_xdp.conf
+++ b/open5gcore_vm/code/one/cac/02_install/files/sysctl_20-5g_xdp.conf
@@ -9,3 +9,6 @@
 net.ipv4.conf.all.rp_filter=2
 net.ipv4.conf.all.accept_local=1
 net.ipv4.conf.all.forwarding=1
+
+net.ipv4.conf.all.send_redirects=0
+net.ipv4.conf.default.send_redirects=0

--- a/open5gs_vm/changelog.md
+++ b/open5gs_vm/changelog.md
@@ -5,6 +5,8 @@
 - New input variable `one_open5gs_vm_install_webui` to enable the installation of the Web UI.
 ### Changed
 - Output dictionary `metadata` renamed to `5gcore_metadata`.
+### Fixed
+- disbale sending of icmp redirect messages for the UPF
 
 
 ## v0.5.1

--- a/open5gs_vm/code/one/cac/02_install/files/sysctl_10-5g_forward.conf
+++ b/open5gs_vm/code/one/cac/02_install/files/sysctl_10-5g_forward.conf
@@ -1,4 +1,7 @@
 net.ipv4.conf.n6.forwarding = 1
 net.ipv4.conf.ogstun.forwarding = 1
-## workaround for wrong interface names..
+## workaround for unpredictable interface names..
 net.ipv4.ip_forward=1
+
+net.ipv4.conf.all.send_redirects=0
+net.ipv4.conf.default.send_redirects=0


### PR DESCRIPTION
configure the UPF of `open5gs` and `open5gcore` to not send icmp-redirect messages for UE traffic.