### PR TITLE
KS8500: Fix Disk Resize method 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## [unreleased] - 2025-XX-XX
 ### Fixed
 - Fixed broken links for components that have appliances in `.tnlcm/public.yaml` file.
+- Fixed disk resize method used in KS8500_runner
 
 ## [v1.0.0] - 2025-09-11
 ### Added

--- a/ks8500_runner/changelog.md
+++ b/ks8500_runner/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 ## v1.16.1.2
 ### Fixed
-- Removed duplicated tn_bastion  in .tnclm/public.yaml 
+- Removed duplicated tn_bastion  in .tnclm/public.yaml
+- Fixed disk resize method.
 ## v1.16.1
 - upgraded runner version 1.16.1
 ## v1.15.1

--- a/ks8500_runner/code/all/runner/docker-compose.yaml
+++ b/ks8500_runner/code/all/runner/docker-compose.yaml
@@ -2,6 +2,7 @@ services:
   runner:
     image: ks8500_runner
     entrypoint: tap runner start
+    restart: unless-stopped
     environment:
       LM_LICENSE_FILE: "@license.opentap.keysight.com"
     volumes:

--- a/ks8500_runner/code/component_playbook.yaml
+++ b/ks8500_runner/code/component_playbook.yaml
@@ -36,22 +36,6 @@
         id: "{{ (terraform_outputs.stdout | from_json)[entity_name + '-id'] }}"
         access_vnet_id: "{{ (terraform_outputs.stdout | from_json)[one_ks8500runner_networks[0] + '-id'] | string }}"
 
-    # For some weird reason, idempotency with this tool gives rc=255, but syntax errors give rc=0...
-    - name: Resize the disk reserved for Longhorn in the storage VMs
-      ansible.builtin.shell: >
-        /usr/local/bin/onevm
-        disk-resize {{ id }} 0 30G
-        --user {{ lookup('ansible.builtin.env', 'OPENNEBULA_USERNAME') }}
-        --password {{ lookup('ansible.builtin.env', 'OPENNEBULA_PASSWORD') }}
-        --endpoint {{ lookup('ansible.builtin.env', 'OPENNEBULA_ENDPOINT') }}
-      register: disk_resize
-      failed_when: >
-        (disk_resize.rc !=  0 and 'must be larger' not in disk_resize.stderr) or
-        ('not found' in disk_resize.stderr)
-      changed_when:
-        - disk_resize.rc == 0
-        - "'not found' not in disk_resize.stderr"
-
     - name: Add new VM to Ansible Inventory
       ansible.builtin.add_host:
         hostname: "ks8500runner"

--- a/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
+++ b/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
@@ -13,17 +13,20 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME: "$NAME"
     USERNAME: "jenkins"
     SSH_PUBLIC_KEY: "$USER[SSH_PUBLIC_KEY]"
-    # install apk add python3
-    START_SCRIPT_BASE64: "IyEvYmluL2Jhc2gKYXBrIGFkZCBweXRob24z"
+    # install apk add python3; growpart /dev/vda 1; resize2fs /dev/vda1
+    START_SCRIPT_BASE64: "IyEvYmluL2Jhc2gKZ3Jvd3BhcnQgL2Rldi92ZGEgMQpyZXNpemUyZnMgL2Rldi92ZGExCmFwayBhZGQgcHl0aG9uMwo="
   }
 
-{# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider
+  # Ignore changes in the disk argument due to limitations in the OpenNebula Terraform provider (#598)
+  lifecycle {
+    ignore_changes = [disk]
+  }
   disk {
-    image_id = {{ site_available_components.ks8500_runner.image_id }}
+    image_id = {{ image_id }}
     size     = {{ one_ks8500runner_disk }}
     target   = "vda"
     driver   = "qcow2"
-  } #}
+  }
 
 
 {% for network in one_ks8500runner_networks %}

--- a/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
+++ b/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
@@ -22,7 +22,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     ignore_changes = [disk]
   }
   disk {
-    image_id = {{ image_id }}
+    image_id = {{ site_available_components.ks8500_runner.image_id }}
     size     = {{ one_ks8500runner_disk }}
     target   = "vda"
     driver   = "qcow2"

--- a/ks8500_runner/variables/one/private.yaml
+++ b/ks8500_runner/variables/one/private.yaml
@@ -14,8 +14,8 @@
 
 one_ks8500runner_cpu: 2
 one_ks8500runner_memory: 16384
-one_ks8500runner_disk: 10000
-one_ks8500runner_networks: 
+one_ks8500runner_disk: 30000
+one_ks8500runner_networks:
   - tn_vxlan
 
 ks8500runner_backend_url: https://test-automation.pw.keysight.com


### PR DESCRIPTION
This PR changes the disk resize method of the KS8500 runner vm to use terraform instead of direct opennebula api access.

tested on berlin & uma