### PR TITLE
open5gs_vm: add loglevel config option, disable SEPP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,10 +3,12 @@
 ## [unreleased] - 2025-XX-XX
 ### Changed
 - Upgraded OpenNebula Terraform provider from 1.4 to 1.5
+- `open5gs_vm` New input variabe `one_open5gs_vm_loglevel` to set the log-level of the open5gs components
 ### Fixed
 - Fixed broken links for components that have appliances in `.tnlcm/public.yaml` file.
 - Fixed `open5gs_k8s` charts not being able to pull mongodb images. Chart version upgraded from `v2.3.1` to `v2.3.3`.
 - Fixed disk resize method used in `ks8500_runner`.
+- Disabled `open5gs-seppd` component of `open5gs_vm`
 
 ## [v1.0.0] - 2025-09-11
 ### Added

--- a/open5gs_vm/.tnlcm/public.yaml
+++ b/open5gs_vm/.tnlcm/public.yaml
@@ -169,6 +169,7 @@ input:
     description: "Loglevel of the open5GS components"
     type: str
     default_value: "warn"
+    required_when: false
     choices:
       - "fatal"
       - "error"

--- a/open5gs_vm/.tnlcm/public.yaml
+++ b/open5gs_vm/.tnlcm/public.yaml
@@ -165,6 +165,17 @@ input:
     type: bool
     default_value: false
     required_when: false
+  one_open5gs_vm_loglevel:
+    description: "Loglevel of the open5GS components"
+    type: str
+    default_value: "warn"
+    choices:
+      - "fatal"
+      - "error"
+      - "warn"
+      - "info"
+      - "debug"
+      - "trace"
 
 ####################################
 ## Generated terraform outputs

--- a/open5gs_vm/changelog.md
+++ b/open5gs_vm/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased] - 2025-XX-XX
+### Added
+- New input variabe `one_open5gs_vm_loglevel` to set the log-level of the open5gs components
+### Changed
+- disable `open5gs-seppd` which was unused and filled the logfile
+
 ## v1.0.0
 ### Added
 - New input variable `one_open5gs_vm_install_webui` to enable the installation of the Web UI.

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -214,3 +214,4 @@
         - open5gs-mmed
         - open5gs-sgwcd
         - open5gs-sgwud
+        - open5gs-seppd

--- a/open5gs_vm/code/one/cac/02_install/templates/open5gs/amf.yaml.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/open5gs/amf.yaml.j2
@@ -2,6 +2,7 @@
 logger:
   file:
     path: /var/log/open5gs/amf.log
+    level: {{ one_open5gs_vm_loglevel }}
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/open5gs_vm/code/one/cac/02_install/templates/open5gs/nrf.yaml.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/open5gs/nrf.yaml.j2
@@ -1,6 +1,7 @@
 logger:
   file:
     path: /var/log/open5gs/nrf.log
+    level: {{ one_open5gs_vm_loglevel }}
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/open5gs_vm/code/one/cac/02_install/templates/open5gs/nssf.yaml.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/open5gs/nssf.yaml.j2
@@ -1,6 +1,7 @@
 logger:
   file:
     path: /var/log/open5gs/nssf.log
+    level: {{ one_open5gs_vm_loglevel }}
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/open5gs_vm/code/one/cac/02_install/templates/open5gs/smf.yaml.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/open5gs/smf.yaml.j2
@@ -1,6 +1,7 @@
 logger:
   file:
     path: /var/log/open5gs/smf.log
+    level: {{ one_open5gs_vm_loglevel }}
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/open5gs_vm/code/one/cac/02_install/templates/open5gs/upf.yaml.j2
+++ b/open5gs_vm/code/one/cac/02_install/templates/open5gs/upf.yaml.j2
@@ -1,6 +1,7 @@
 logger:
   file:
     path: /var/log/open5gs/upf.log
+    level: {{ one_open5gs_vm_loglevel }}
 #  level: info   # fatal|error|warn|info(default)|debug|trace
 
 global:

--- a/open5gs_vm/sample_input_file.yaml
+++ b/open5gs_vm/sample_input_file.yaml
@@ -23,3 +23,4 @@ one_open5gs_vm_upf_n3_ip: "10.10.10.201"
 # one_open5gs_vm_s_nssai_sst: 1
 # one_open5gs_vm_s_nssai_sd: "000001"
 # one_open5gs_vm_use_nightly: false
+# one_open5gs_vm_loglevel: watn

--- a/open5gs_vm/sample_tnlcm_descriptor.yaml
+++ b/open5gs_vm/sample_tnlcm_descriptor.yaml
@@ -51,3 +51,4 @@ trial_network:
       # one_open5gs_vm_s_nssai_sd: "000001"        # Default value
       # one_open5gs_vm_use_nightly: false          # Default value
       one_open5gs_vm_install_webui: true
+      one_open5gs_vm_loglevel: info

--- a/open5gs_vm/variables/one/private.yaml
+++ b/open5gs_vm/variables/one/private.yaml
@@ -52,3 +52,4 @@ one_open5gs_vm_apn: "internet"
 one_open5gs_vm_s_nssai_sst: 1
 one_open5gs_vm_s_nssai_sd: "000001"
 one_open5gs_vm_use_nightly: false
+one_open5gs_vm_loglevel: "warn"


### PR DESCRIPTION
add `one_open5gs_vm_loglevel` variable to open5gs_vm componnet (defaults to warn)
disable SEPP componnet that just fills up the disk ad is unused.
