### PR TITLE
open5gs: fetch timeout on gui installation & berlin_ran fix

### DIFF
--- a/berlin_ran/code/component_playbook.yaml
+++ b/berlin_ran/code/component_playbook.yaml
@@ -29,7 +29,7 @@
         current_timestamp: "{{ any_berlin_ran_start_time | default(lookup('pipe', 'date -u +\"%Y-%m-%dT%H:%M:%SZ\"'), true) }}"
     - name: Set end of lease time and date with RFC 3339 section 5.6 format
       ansible.builtin.set_fact:
-        ending_timestamp: "{{ lookup('pipe', 'date -u -d \"' ~ start_time ~ ' + ' ~ any_berlin_ran_duration ~ ' seconds\" +\"%Y-%m-%dT%H:%M:%SZ\"') }}"
+        ending_timestamp: "{{ lookup('pipe', 'date -u -d \"' ~ current_timestamp ~ ' + ' ~ any_berlin_ran_duration ~ ' seconds\" +\"%Y-%m-%dT%H:%M:%SZ\"') }}"
 
     - name: Submit routes in route-manager-api from the Berlin RAN to the 5G Core
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/routemanager_add.yaml"

--- a/berlin_ran/sample_tnlcm_descriptor.yaml
+++ b/berlin_ran/sample_tnlcm_descriptor.yaml
@@ -12,8 +12,8 @@ trial_network:
     input:
       one_vnet_first_ip: "10.10.11.1"
       one_vnet_netmask: 24
-      one_vnet_gw: null # there is no gateway in this network
-      one_vnet_dns: null # there is no DNS in this network
+      #one_vnet_gw: null # there is no gateway in this network
+      #one_vnet_dns: null # there is no DNS in this network
   open5gcore_vm-core:
     type: "open5gcore_vm"
     name: "core"

--- a/open5gs_vm/code/one/cac/02_install/install_webui.yaml
+++ b/open5gs_vm/code/one/cac/02_install/install_webui.yaml
@@ -23,7 +23,11 @@
     url: https://open5gs.org/open5gs/assets/webui/install
     dest: /opt/install-oopen5gs-webui.sh
     mode: '0755'
+    status_code: [200]
   register: add_webui_script
+  until: add_webui_script.status == 200
+  retries: 3
+  delay: 10
 
 - name: Install WebUI from source
   ansible.builtin.command:


### PR DESCRIPTION
- fixes a variable name in the berlin_ran componnet
- adds a timeout based retry to the open5gs_vm web-gui installation