### PR TITLE
Add OneKE support for OpenNebula 7.0

### DIFF
--- a/oneKE/code/one/iac/oneKE.tf.j2
+++ b/oneKE/code/one/iac/oneKE.tf.j2
@@ -44,7 +44,7 @@ resource "opennebula_service" "{{ entity_name }}" {
         "ONEAPP_STORAGE_FILESYSTEM": "xfs",       {# for OpenNebula <  7.0 #}
         "ONEAPP_K8S_TRAEFIK_ENABLED": "{% if one_oneKE_traefik %}YES{% else %}NO{% endif %}",
         "ONEAPP_VNF_HAPROXY_INTERFACES": "eth0",
-        "ONEAPP_VNF_HAPROXY_REFRESH_RATE": "30",å
+        "ONEAPP_VNF_HAPROXY_REFRESH_RATE": "30",
         "ONEAPP_VNF_HAPROXY_LB0_PORT": "9345",
         "ONEAPP_VNF_HAPROXY_LB1_PORT": "6443",
         "ONEAPP_VNF_HAPROXY_LB2_PORT": "443",

--- a/oneKE/code/one/iac/oneKE.tf.j2
+++ b/oneKE/code/one/iac/oneKE.tf.j2
@@ -38,13 +38,13 @@ resource "opennebula_service" "{{ entity_name }}" {
         "ONEAPP_K8S_METALLB_RANGE": "",
         "ONEAPP_K8S_METALLB_CONFIG": "",
         "ONEAPP_K8S_LONGHORN_ENABLED": "{% if one_oneKE_longhorn %}YES{% else %}NO{% endif %}",
-        "ONEAPP_STORAGE_DEVICE": "/dev/vdb",
-        "ONEAPP_STORAGE_FILESYSTEM": "xfs",
-        "ONEAPP_K8S_STORAGE_DEVICE": "/dev/vdb",
-        "ONEAPP_STORAGE_FILESYSTEM": "xfs",
+        "ONEAPP_K8S_STORAGE_DEVICE": "/dev/vdb",  {# for OpenNebula >= 7.0 #}
+        "ONEAPP_STORAGE_DEVICE": "/dev/vdb",      {# for OpenNebula <  7.0 #}
+        "ONEAPP_K8S_STORAGE_FILESYSTEM": "xfs",   {# for OpenNebula >= 7.0 #}
+        "ONEAPP_STORAGE_FILESYSTEM": "xfs",       {# for OpenNebula <  7.0 #}
         "ONEAPP_K8S_TRAEFIK_ENABLED": "{% if one_oneKE_traefik %}YES{% else %}NO{% endif %}",
         "ONEAPP_VNF_HAPROXY_INTERFACES": "eth0",
-        "ONEAPP_VNF_HAPROXY_REFRESH_RATE": "30",
+        "ONEAPP_VNF_HAPROXY_REFRESH_RATE": "30",å
         "ONEAPP_VNF_HAPROXY_LB0_PORT": "9345",
         "ONEAPP_VNF_HAPROXY_LB1_PORT": "6443",
         "ONEAPP_VNF_HAPROXY_LB2_PORT": "443",

--- a/oneKE/code/one/iac/oneKE.tf.j2
+++ b/oneKE/code/one/iac/oneKE.tf.j2
@@ -40,6 +40,8 @@ resource "opennebula_service" "{{ entity_name }}" {
         "ONEAPP_K8S_LONGHORN_ENABLED": "{% if one_oneKE_longhorn %}YES{% else %}NO{% endif %}",
         "ONEAPP_STORAGE_DEVICE": "/dev/vdb",
         "ONEAPP_STORAGE_FILESYSTEM": "xfs",
+        "ONEAPP_K8S_STORAGE_DEVICE": "/dev/vdb",
+        "ONEAPP_STORAGE_FILESYSTEM": "xfs",
         "ONEAPP_K8S_TRAEFIK_ENABLED": "{% if one_oneKE_traefik %}YES{% else %}NO{% endif %}",
         "ONEAPP_VNF_HAPROXY_INTERFACES": "eth0",
         "ONEAPP_VNF_HAPROXY_REFRESH_RATE": "30",


### PR DESCRIPTION
OneKE official templates for OpenNebula 7.0 rename two of its parameters.
Despite having default variables, if they are not declared in the terraform manifests, the terrraform plan fails with no useful log.
New variables are added along the old ones for backwards compatibility