### PR TITLE
fix(prometheus): rename 'description' to 'long_description' in public.yaml

### DIFF
--- a/prometheus/.tnlcm/public.yaml
+++ b/prometheus/.tnlcm/public.yaml
@@ -15,7 +15,7 @@ metadata:
   maintainers:
     - Carlos Andreo López <c.andreo@uma.es>
   short_description: Deploy a virtual machine with Prometheus installed
-  description: |
+  long_description: |
     Ubuntu 22.04 LTS virtual machine with Prometheus installed. 
 
     Prometheus is an open-source systems monitoring and alerting toolkit originally built at SoundCloud. It is designed for reliability and scalability, allowing users to collect and store metrics as time series data, providing powerful querying capabilities and a flexible alerting system. Prometheus is widely used for monitoring cloud-native applications, microservices and containerized environments, making it a popular choice in the DevOps community.


### PR DESCRIPTION
fix(prometheus): rename 'description' to 'long_description' in public.yaml

Fix incorrect field name in prometheus component metadata. The toolkit
installer requires 'long_description' field in .tnlcm and fails when not found.