### PR TITLE
fix: resize OneKE disks via Ruby API #PROESP-2752

### DIFF
--- a/.dummy_component/code/component_playbook.yaml
+++ b/.dummy_component/code/component_playbook.yaml
@@ -86,7 +86,14 @@
       ansible.builtin.add_host:
         hostname: "new_host"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     # While not used by the Jenkins, we included the configuration of a .ssh/config per TN in the Jenkins VM for debugging purposes.

--- a/.dummy_component/code/component_playbook.yaml
+++ b/.dummy_component/code/component_playbook.yaml
@@ -89,7 +89,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/.dummy_component/code/one/iac/dummy_component.tf.j2
+++ b/.dummy_component/code/one/iac/dummy_component.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/.global/cac/load_variables.yaml
+++ b/.global/cac/load_variables.yaml
@@ -16,3 +16,7 @@
 - name: Load public component-specific variables from input file
   ansible.builtin.include_vars:
     file: "{{ workspace }}/{{ component_type }}/variables/input_file.yaml"
+
+- name: Set Jenkins SSH public key from local file
+  ansible.builtin.set_fact:
+    jenkins_ssh_public_key: "{{ lookup('file', '/var/lib/jenkins/.ssh/id_ed25519.pub') }}"

--- a/.global/cac/s3_download.yaml
+++ b/.global/cac/s3_download.yaml
@@ -1,3 +1,12 @@
+- name: Ensure S3 bucket exists
+  amazon.aws.s3_bucket:
+    name: "{{ site_s3_server.bucket }}"
+    state: present
+    endpoint_url: "{{ site_s3_server.endpoint }}"
+    access_key: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
+    secret_key: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
+    validate_certs: false
+
 - name: Get list of files from S3 object storage
   amazon.aws.s3_object:
     endpoint_url: "{{ site_s3_server.endpoint }}"

--- a/.global/cac/tn_destroy.yaml
+++ b/.global/cac/tn_destroy.yaml
@@ -61,13 +61,13 @@
       ansible.builtin.command:
         cmd: "terraform state rm {{ item.address }}"
         chdir: "{{ workspace }}/.terraform/"
-      loop: "{{ (tf_state_dump.stdout | from_json).values.root_module.resources | default([]) }}"
+      loop: "{{ (tf_state_dump.stdout | from_json)['values']['root_module']['resources'] | default([]) }}"
       loop_control:
         label: "{{ item.address }}"
       when: >-
         stale_ar_vnet_ids | length > 0 and
         item.type == 'opennebula_virtual_network_address_range' and
-        (item.values.virtual_network_id | string) in stale_ar_vnet_ids
+        (item['values']['virtual_network_id'] | string) in stale_ar_vnet_ids
       ignore_errors: true
 
     - name: Run 'terraform apply' a second time. Command should now succeed

--- a/.global/cac/tn_destroy.yaml
+++ b/.global/cac/tn_destroy.yaml
@@ -53,25 +53,21 @@
       ansible.builtin.set_fact:
         stale_ar_vnet_ids: "{{ (first_apply_result.msg | default('')) | regex_findall('Virtual network \\(ID:(\\d+)\\): AR \\(ID:\\d+\\)') }}"
 
-    - name: Compute terraform state addresses for the stale Address Range resources
-      ansible.builtin.set_fact:
-        stale_ar_state_addresses: >-
-          {{
-            (tf_state_dump.stdout | from_json).values.root_module.resources
-            | default([])
-            | selectattr('type', 'equalto', 'opennebula_virtual_network_address_range')
-            | selectattr('values.virtual_network_id', 'in', stale_ar_vnet_ids)
-            | map(attribute='address')
-            | list
-          }}
-      when: stale_ar_vnet_ids | length > 0
-
+    # virtual_network_id may be tracked as an int or a string depending on provider
+    # version, while stale_ar_vnet_ids (from regex_findall) is always a list of strings;
+    # cast explicitly per-item in the `when` below so the comparison isn't silently
+    # type-mismatched (a selectattr('..., 'in', ...) pipeline can't cast inline).
     - name: Remove stale Address Range entries from terraform state so the retry can proceed
       ansible.builtin.command:
-        cmd: "terraform state rm {{ item }}"
+        cmd: "terraform state rm {{ item.address }}"
         chdir: "{{ workspace }}/.terraform/"
-      loop: "{{ stale_ar_state_addresses | default([]) }}"
-      when: stale_ar_vnet_ids | length > 0
+      loop: "{{ (tf_state_dump.stdout | from_json).values.root_module.resources | default([]) }}"
+      loop_control:
+        label: "{{ item.address }}"
+      when: >-
+        stale_ar_vnet_ids | length > 0 and
+        item.type == 'opennebula_virtual_network_address_range' and
+        (item.values.virtual_network_id | string) in stale_ar_vnet_ids
       ignore_errors: true
 
     - name: Run 'terraform apply' a second time. Command should now succeed

--- a/.global/cac/tn_destroy.yaml
+++ b/.global/cac/tn_destroy.yaml
@@ -32,6 +32,44 @@
         state: "present"
         force_init: true
       ignore_errors: true
+      register: first_apply_result
+
+    # The OpenNebula terraform provider can hard-error on refresh/plan when an
+    # opennebula_virtual_network_address_range's AR was already removed from OpenNebula
+    # (e.g. destroyed as a side effect of the first, ignored apply above) but the AR
+    # resource itself is still tracked in state. Drop just those stale AR entries so the
+    # retry below can proceed instead of failing again with "AR not found".
+    - name: Dump current terraform state as JSON to detect stale Address Ranges
+      ansible.builtin.command:
+        cmd: terraform show -json
+        chdir: "{{ workspace }}/.terraform/"
+      register: tf_state_dump
+      changed_when: false
+
+    - name: Identify OpenNebula Virtual Network IDs reported as having a missing Address Range
+      ansible.builtin.set_fact:
+        stale_ar_vnet_ids: "{{ (first_apply_result.msg | default('')) | regex_findall('Virtual network \\(ID:(\\d+)\\): AR \\(ID:\\d+\\) not found') }}"
+
+    - name: Compute terraform state addresses for the stale Address Range resources
+      ansible.builtin.set_fact:
+        stale_ar_state_addresses: >-
+          {{
+            (tf_state_dump.stdout | from_json).values.root_module.resources
+            | default([])
+            | selectattr('type', 'equalto', 'opennebula_virtual_network_address_range')
+            | selectattr('values.virtual_network_id', 'in', stale_ar_vnet_ids)
+            | map(attribute='address')
+            | list
+          }}
+      when: stale_ar_vnet_ids | length > 0
+
+    - name: Remove stale Address Range entries from terraform state so the retry can proceed
+      ansible.builtin.command:
+        cmd: "terraform state rm {{ item }}"
+        chdir: "{{ workspace }}/.terraform/"
+      loop: "{{ stale_ar_state_addresses | default([]) }}"
+      when: stale_ar_vnet_ids | length > 0
+      ignore_errors: true
 
     - name: Run 'terraform apply' a second time. Command should now succeed
       community.general.terraform:

--- a/.global/cac/tn_destroy.yaml
+++ b/.global/cac/tn_destroy.yaml
@@ -46,9 +46,12 @@
       register: tf_state_dump
       changed_when: false
 
+    # Matches both observed OpenNebula provider error phrasings for a stale AR:
+    #   "Virtual network (ID:X): AR (ID:Y) not found"
+    #   "Virtual network (ID:X): AR (ID:Y): OpenNebula error [INTERNAL]: [one.vn.free_ar] Address Range does not exist"
     - name: Identify OpenNebula Virtual Network IDs reported as having a missing Address Range
       ansible.builtin.set_fact:
-        stale_ar_vnet_ids: "{{ (first_apply_result.msg | default('')) | regex_findall('Virtual network \\(ID:(\\d+)\\): AR \\(ID:\\d+\\) not found') }}"
+        stale_ar_vnet_ids: "{{ (first_apply_result.msg | default('')) | regex_findall('Virtual network \\(ID:(\\d+)\\): AR \\(ID:\\d+\\)') }}"
 
     - name: Compute terraform state addresses for the stale Address Range resources
       ansible.builtin.set_fact:

--- a/elcm/code/component_playbook.yaml
+++ b/elcm/code/component_playbook.yaml
@@ -73,7 +73,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/elcm/code/component_playbook.yaml
+++ b/elcm/code/component_playbook.yaml
@@ -94,7 +94,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/elcm/code/component_playbook.yaml
+++ b/elcm/code/component_playbook.yaml
@@ -70,7 +70,14 @@
       ansible.builtin.add_host:
         hostname: "elcm"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/elcm/code/one/iac/elcm.tf.j2
+++ b/elcm/code/one/iac/elcm.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_ELCM_PORTAL_ENABLE =     "YES"
     ONEAPP_ELCM_INFLUXDB_ENABLE =   "YES"
     ONEAPP_ELCM_INFLUXDB_HOST =     "{{ influxdb_configuration.host }}"

--- a/elcm/code/one/iac/elcm.tf.j2
+++ b/elcm/code/one/iac/elcm.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_ELCM_PORTAL_ENABLE =     "YES"
     ONEAPP_ELCM_INFLUXDB_ENABLE =   "YES"
     ONEAPP_ELCM_INFLUXDB_HOST =     "{{ influxdb_configuration.host }}"

--- a/elcm/code/one/iac/elcm.tf.j2
+++ b/elcm/code/one/iac/elcm.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_ELCM_PORTAL_ENABLE =     "YES"
     ONEAPP_ELCM_INFLUXDB_ENABLE =   "YES"
     ONEAPP_ELCM_INFLUXDB_HOST =     "{{ influxdb_configuration.host }}"

--- a/grafana/code/component_playbook.yaml
+++ b/grafana/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "grafana"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/grafana/code/component_playbook.yaml
+++ b/grafana/code/component_playbook.yaml
@@ -74,7 +74,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/grafana/code/component_playbook.yaml
+++ b/grafana/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/grafana/code/one/iac/grafana.tf.j2
+++ b/grafana/code/one/iac/grafana.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_GRAFANA_VERSION =   "{{ one_grafana_version }}"
     ONEAPP_GRAFANA_ADMIN_PASSWORD =  "{{ one_grafana_password }}"
   }

--- a/grafana/code/one/iac/grafana.tf.j2
+++ b/grafana/code/one/iac/grafana.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_GRAFANA_VERSION =   "{{ one_grafana_version }}"
     ONEAPP_GRAFANA_ADMIN_PASSWORD =  "{{ one_grafana_password }}"
   }

--- a/grafana/code/one/iac/grafana.tf.j2
+++ b/grafana/code/one/iac/grafana.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_GRAFANA_VERSION =   "{{ one_grafana_version }}"
     ONEAPP_GRAFANA_ADMIN_PASSWORD =  "{{ one_grafana_password }}"
   }

--- a/influxdb/code/component_playbook.yaml
+++ b/influxdb/code/component_playbook.yaml
@@ -74,7 +74,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/influxdb/code/component_playbook.yaml
+++ b/influxdb/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/influxdb/code/component_playbook.yaml
+++ b/influxdb/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "influxdb"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/influxdb/code/one/iac/influxdb.tf.j2
+++ b/influxdb/code/one/iac/influxdb.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_INFLUXDB_VERSION =  "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =     "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD = "{{ one_influxdb_password }}"

--- a/influxdb/code/one/iac/influxdb.tf.j2
+++ b/influxdb/code/one/iac/influxdb.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_INFLUXDB_VERSION =  "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =     "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD = "{{ one_influxdb_password }}"

--- a/influxdb/code/one/iac/influxdb.tf.j2
+++ b/influxdb/code/one/iac/influxdb.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_INFLUXDB_VERSION =  "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =     "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD = "{{ one_influxdb_password }}"

--- a/int_p4_sw/code/component_playbook.yaml
+++ b/int_p4_sw/code/component_playbook.yaml
@@ -56,7 +56,14 @@
       ansible.builtin.add_host:
         hostname: "int_p4_switch_{{ item.key }}"
         ansible_host: "{{ item.value[switch_first_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
       loop: "{{ switch_ips | dict2items }}"
 
@@ -65,7 +72,14 @@
       ansible.builtin.add_host:
         hostname: "int_p4_collector"
         ansible_host: "{{ collector_ips[collector_first_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/int_p4_sw/code/component_playbook.yaml
+++ b/int_p4_sw/code/component_playbook.yaml
@@ -95,7 +95,7 @@
         - name: Wait for system to become reachable
           ansible.builtin.wait_for_connection:
             connect_timeout: 5
-            timeout: 200
+            timeout: 600
 
         - name: Set site ssh key as authorized in jenkins user
           ansible.posix.authorized_key:

--- a/int_p4_sw/code/component_playbook.yaml
+++ b/int_p4_sw/code/component_playbook.yaml
@@ -59,7 +59,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no
@@ -75,7 +77,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
@@ -11,6 +11,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_collector" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
@@ -10,7 +10,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_collector" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_collector_p4_sw.tf.j2
@@ -12,8 +12,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_collector" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_{{ switch_index }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {% for network in switch_config.networks %}

--- a/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_{{ switch_index }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {% for network in switch_config.networks %}

--- a/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
+++ b/int_p4_sw/code/one/iac/int_switch_p4_sw.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}_{{ switch_index }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {% for network in switch_config.networks %}

--- a/ixc_endpoint/code/component_playbook.yaml
+++ b/ixc_endpoint/code/component_playbook.yaml
@@ -80,7 +80,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/ixc_endpoint/code/component_playbook.yaml
+++ b/ixc_endpoint/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "endpoint"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add the bastion to Ansible Inventory

--- a/ixc_endpoint/code/component_playbook.yaml
+++ b/ixc_endpoint/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
+++ b/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
@@ -10,6 +10,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_IXCHARIOT_ENDPOINT_RS_ADDRESS = "{{ one_ixc_endpoint_rs }}"
   }
 

--- a/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
+++ b/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
@@ -11,8 +11,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_IXCHARIOT_ENDPOINT_RS_ADDRESS = "{{ one_ixc_endpoint_rs }}"
   }
 

--- a/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
+++ b/ixc_endpoint/code/one/iac/ixc_endpoint.tf.j2
@@ -9,7 +9,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_IXCHARIOT_ENDPOINT_RS_ADDRESS = "{{ one_ixc_endpoint_rs }}"
   }
 

--- a/ks8500_runner/code/component_playbook.yaml
+++ b/ks8500_runner/code/component_playbook.yaml
@@ -43,7 +43,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/ks8500_runner/code/component_playbook.yaml
+++ b/ks8500_runner/code/component_playbook.yaml
@@ -40,7 +40,14 @@
       ansible.builtin.add_host:
         hostname: "ks8500runner"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add tn_bastion to Ansible Inventory

--- a/ks8500_runner/code/component_playbook.yaml
+++ b/ks8500_runner/code/component_playbook.yaml
@@ -87,7 +87,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
+++ b/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
@@ -13,7 +13,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME: "$NAME"
     USERNAME: "jenkins"
     PASSWORD: "keysight"
-    SSH_PUBLIC_KEY: "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY: "{{ jenkins_ssh_public_key }}"
     # install apt install python3 -y; growpart /dev/vda 1; resize2fs /dev/vda1
     START_SCRIPT_BASE64: "IyEvYmluL2Jhc2gKZ3Jvd3BhcnQgL2Rldi92ZGEgMQpyZXNpemUyZnMgL2Rldi92ZGExCmFwdCBpbnN0YWxsIHB5dGhvbjMgLXk="
   }

--- a/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
+++ b/ks8500_runner/code/one/iac/ks8500_runner.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME: "jenkins"
     PASSWORD: "keysight"
     SSH_PUBLIC_KEY: "{{ jenkins_ssh_public_key }}"
-    # install apt install python3 -y; growpart /dev/vda 1; resize2fs /dev/vda1
-    START_SCRIPT_BASE64: "IyEvYmluL2Jhc2gKZ3Jvd3BhcnQgL2Rldi92ZGEgMQpyZXNpemUyZnMgL2Rldi92ZGExCmFwdCBpbnN0YWxsIHB5dGhvbjMgLXk="
+    # Disable unattended-upgrades at first boot; then growpart + resize2fs + apt install python3
+    START_SCRIPT_BASE64: "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCmdyb3dwYXJ0IC9kZXYvdmRhIDEKcmVzaXplMmZzIC9kZXYvdmRhMQphcHQgaW5zdGFsbCBweXRob24zIC15Cg=="
   }
 
   # Ignore changes in the disk argument due to limitations in the OpenNebula Terraform provider (#598)

--- a/loadcore_agent/code/component_playbook.yaml
+++ b/loadcore_agent/code/component_playbook.yaml
@@ -56,7 +56,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/loadcore_agent/code/component_playbook.yaml
+++ b/loadcore_agent/code/component_playbook.yaml
@@ -53,7 +53,14 @@
       ansible.builtin.add_host:
         hostname: "loadcore_agent"
         ansible_host: "{{ ips[access_vnet_id][0] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add tn_bastion to Ansible Inventory

--- a/loadcore_agent/code/component_playbook.yaml
+++ b/loadcore_agent/code/component_playbook.yaml
@@ -83,7 +83,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/loadcore_agent/code/one/iac/loadcore_agent.tf.j2
+++ b/loadcore_agent/code/one/iac/loadcore_agent.tf.j2
@@ -13,7 +13,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKZ3Jvd3BhcnQgL2Rldi92ZGEgMQpyZXNpemUyZnMgL2Rldi92ZGEx"
+    # Disable unattended-upgrades at first boot; then growpart + resize2fs
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCmdyb3dwYXJ0IC9kZXYvdmRhIDEKcmVzaXplMmZzIC9kZXYvdmRhMQo="
   }
 
   # Ignore changes in the disk argument due to limitations in the OpenNebula Terraform provider (#598)

--- a/loadcore_agent/code/one/iac/loadcore_agent.tf.j2
+++ b/loadcore_agent/code/one/iac/loadcore_agent.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKZ3Jvd3BhcnQgL2Rldi92ZGEgMQpyZXNpemUyZnMgL2Rldi92ZGEx"
   }
 

--- a/mongodb/code/component_playbook.yaml
+++ b/mongodb/code/component_playbook.yaml
@@ -71,7 +71,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/mongodb/code/component_playbook.yaml
+++ b/mongodb/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "mongodb"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/mongodb/code/component_playbook.yaml
+++ b/mongodb/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/mongodb/code/one/iac/mongodb.tf.j2
+++ b/mongodb/code/one/iac/mongodb.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_MONGODB_VERSION =        "{{ one_mongodb_version }}"
     ONEAPP_MONGODB_USER =           "{{ one_mongodb_user }}"
     ONEAPP_MONGODB_PASSWORD =       "{{ one_mongodb_password }}"

--- a/mongodb/code/one/iac/mongodb.tf.j2
+++ b/mongodb/code/one/iac/mongodb.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_MONGODB_VERSION =        "{{ one_mongodb_version }}"
     ONEAPP_MONGODB_USER =           "{{ one_mongodb_user }}"
     ONEAPP_MONGODB_PASSWORD =       "{{ one_mongodb_password }}"

--- a/mongodb/code/one/iac/mongodb.tf.j2
+++ b/mongodb/code/one/iac/mongodb.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_MONGODB_VERSION =        "{{ one_mongodb_version }}"
     ONEAPP_MONGODB_USER =           "{{ one_mongodb_user }}"
     ONEAPP_MONGODB_PASSWORD =       "{{ one_mongodb_password }}"

--- a/monitoring/code/component_playbook.yaml
+++ b/monitoring/code/component_playbook.yaml
@@ -71,7 +71,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/monitoring/code/component_playbook.yaml
+++ b/monitoring/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/monitoring/code/component_playbook.yaml
+++ b/monitoring/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "monitoring"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/monitoring/code/one/iac/monitoring.tf.j2
+++ b/monitoring/code/one/iac/monitoring.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_INFLUXDB_VERSION =        "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =           "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD =       "{{ one_influxdb_password }}"

--- a/monitoring/code/one/iac/monitoring.tf.j2
+++ b/monitoring/code/one/iac/monitoring.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_INFLUXDB_VERSION =        "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =           "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD =       "{{ one_influxdb_password }}"

--- a/monitoring/code/one/iac/monitoring.tf.j2
+++ b/monitoring/code/one/iac/monitoring.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_INFLUXDB_VERSION =        "{{ one_influxdb_version }}"
     ONEAPP_INFLUXDB_USER =           "{{ one_influxdb_user }}"
     ONEAPP_INFLUXDB_PASSWORD =       "{{ one_influxdb_password }}"

--- a/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
+++ b/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
@@ -1,0 +1,64 @@
+trial_network:
+  tn_init:
+    type: "tn_init"
+    dependencies: []
+    input: {}
+
+  tn_bastion-bastion:
+    type: "tn_bastion"
+    name: "bastion"
+    dependencies:
+      - "tn_init"
+    input: {}
+
+  vnet-n3:
+    type: "vnet"
+    name: "n3"
+    dependencies:
+      - "tn_init"
+    input:
+      one_vnet_first_ip: "10.10.12.1"   # nokia_radio hardcodes AMF at .200 and UPF at .201
+
+  vnet-n6:
+    type: "vnet"
+    name: "n6"
+    dependencies:
+      - "tn_init"
+    input:
+      one_vnet_first_ip: "10.11.6.1"
+
+  upf_p4_sw-core:
+    type: "upf_p4_sw"
+    name: "core"
+    dependencies:
+      - "tn_init"
+      - "tn_bastion-bastion"
+      - "vnet-n3"
+      - "vnet-n6"
+    input:
+      one_upf_p4_sw_networks:
+        - tn_vxlan
+        - vnet-n3
+        - vnet-n6
+      # Must match nokia_radio hardcoded requirements:
+      one_upf_p4_sw_open5gs_amf_ngap_addr: "10.10.12.200"
+      one_upf_p4_sw_controller_upf_ipv4_n3: "10.10.12.201"
+      one_upf_p4_sw_open5gs_control_tac: 1
+      one_upf_p4_sw_open5gs_control_mcc: "214"
+      one_upf_p4_sw_open5gs_control_mnc: "702"
+      one_upf_p4_sw_open5gs_control_msin: "000000600"
+      one_upf_p4_sw_open5gs_control_s_nssai_sd: "000009"
+      # N6 side
+      one_upf_p4_sw_controller_upf_ipv4_n6: "10.11.6.1"
+      one_upf_p4_sw_controller_dn_ipv4_n6: "10.11.6.2"
+      # Nokia radio's physical N3 IP — update when real radio is installed
+      one_upf_p4_sw_controller_enb_ipv4_n3: "192.168.77.11"   # placeholder from core.yaml
+
+  nokia_radio-RAN:
+    type: "nokia_radio"
+    name: "RAN"
+    dependencies:
+      - "upf_p4_sw-core"
+    input:
+      any_nokia_radio_linked_5gcore: "
+      any_nokia_radio_duration: 7200

--- a/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
+++ b/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
@@ -4,13 +4,6 @@ trial_network:
     dependencies: []
     input: {}
 
-  tn_bastion-bastion:
-    type: "tn_bastion"
-    name: "bastion"
-    dependencies:
-      - "tn_init"
-    input: {}
-
   vnet-n3:
     type: "vnet"
     name: "n3"

--- a/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
+++ b/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
@@ -60,5 +60,5 @@ trial_network:
     dependencies:
       - "upf_p4_sw-core"
     input:
-      any_nokia_radio_linked_5gcore: "
+      any_nokia_radio_linked_5gcore: "upf_p4_sw-core"
       any_nokia_radio_duration: 7200

--- a/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
+++ b/nokia_radio/sample_tnlcm_descriptor_la_mayora_upf4.yaml
@@ -25,7 +25,6 @@ trial_network:
     name: "core"
     dependencies:
       - "tn_init"
-      - "tn_bastion-bastion"
       - "vnet-n3"
       - "vnet-n6"
     input:

--- a/oneKE/code/component_playbook.yaml
+++ b/oneKE/code/component_playbook.yaml
@@ -109,7 +109,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/oneKE/code/component_playbook.yaml
+++ b/oneKE/code/component_playbook.yaml
@@ -61,12 +61,20 @@
 
     # For some weird reason, idempotency with this tool gives rc=255, but syntax errors give rc=0...
     - name: Resize the disk reserved for Longhorn in the storage VMs
-      ansible.builtin.shell: >
-        /usr/bin/onevm
-        disk-resize {{ item }} 1 30G
-        --user {{ lookup('ansible.builtin.env', 'OPENNEBULA_USERNAME') }}
-        --password {{ lookup('ansible.builtin.env', 'OPENNEBULA_PASSWORD') }}
-        --endpoint {{ lookup('ansible.builtin.env', 'OPENNEBULA_ENDPOINT') }}
+      ansible.builtin.shell: |
+        ruby - "{{ item }}" <<'RUBY'
+        require 'opennebula'
+
+        auth = "#{ENV.fetch('OPENNEBULA_USERNAME')}:#{ENV.fetch('OPENNEBULA_PASSWORD')}"
+        client = OpenNebula::Client.new(auth, ENV.fetch('OPENNEBULA_ENDPOINT'))
+        vm = OpenNebula::VirtualMachine.new_with_id(Integer(ARGV.fetch(0)), client)
+        rc = vm.disk_resize(1, 30 * 1024)
+
+        if OpenNebula.is_error?(rc)
+          warn rc.message
+          exit 255
+        end
+        RUBY
       register: disk_resize
       failed_when: >
         (disk_resize.rc !=  0 and 'must be larger' not in disk_resize.stderr) or

--- a/open5gcore_vm/code/component_playbook.yaml
+++ b/open5gcore_vm/code/component_playbook.yaml
@@ -80,7 +80,14 @@
       ansible.builtin.add_host:
         hostname: "open5gcore_vm"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/open5gcore_vm/code/component_playbook.yaml
+++ b/open5gcore_vm/code/component_playbook.yaml
@@ -83,7 +83,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/open5gcore_vm/code/component_playbook.yaml
+++ b/open5gcore_vm/code/component_playbook.yaml
@@ -101,7 +101,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
+++ b/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
+++ b/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
+++ b/open5gcore_vm/code/one/iac/open5gcore_vm.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gs_vm/.tnlcm/public.yaml
+++ b/open5gs_vm/.tnlcm/public.yaml
@@ -19,7 +19,7 @@ metadata:
   short_description: Deploys a Open5GS as a standalone Virtual Machine
   long_description: |
     Deploys a Open5GS over a general-purpose Virtual Machine based on Ubuntu 22.04 lTS.
-    The automation is installing Open5GS version 2.7.6 and MongoDB on it.
+    The automation is installing Open5GS version 2.8.0 and MongoDB on it.
     Through variable "one_open5gs_vm_size", five different types of instances can be deployed
     - **extra_large**: 32 GiB of memory, 8 vCPU and 100GiB of storage
     - **large**: 16 GiB of memory, 4 vCPU and 50GiB of storage

--- a/open5gs_vm/README.md
+++ b/open5gs_vm/README.md
@@ -2,7 +2,7 @@
 
 The **open5gs_vm** 6G-Library component deploys a 5G SA Core inside an Ubuntu VM using scripts.
 Current versions:
-- Open5GS v2.7.6
+- Open5GS v2.8.0
 
 > [!NOTE]  
 > The VM needs a CPU architecture with the vmx instructions set.
@@ -54,7 +54,7 @@ Deploys a Open5GS as a standalone Virtual Machine
 ## Long Description
 
 Deploys a Open5GS over a general-purpose Virtual Machine based on Ubuntu 22.04 LTS.  
-The automation installs Open5GS version 2.7.6 and MongoDB on it.  
+The automation installs Open5GS version 2.8.0 and MongoDB on it.  
 Through variable `one_open5gs_vm_size`, five different types of instances can be deployed:
 
 - **extra_large**: 32 GiB of memory, 8 vCPU and 100GiB of storage  

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -97,6 +97,8 @@
         path: "/tmp/ansible-ssh-{{ ansible_host }}-22-{{ ansible_user }}"
         state: absent
       delegate_to: localhost
+      vars:
+        ansible_connection: local
 
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -138,6 +138,14 @@
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
         delay: 5
+        timeout: 600
+      ignore_unreachable: true
+      ignore_errors: true
+
+    - name: Confirm SSH is stable before first remote task
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
         timeout: 300
 
     - name: Wait for cloud-init to complete so sshd is no longer restarted

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -77,6 +77,7 @@
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
+        ansible_pipelining: true
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -93,7 +93,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -69,7 +69,14 @@
       ansible.builtin.add_host:
         hostname: "open5gs_vm"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }} -o KexAlgorithms=curve25519-sha256"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -71,6 +71,7 @@
         ansible_host: "{{ ips[access_vnet_id] }}"
         ansible_ssh_common_args: >-
           -F /dev/null
+          -S none
           -o ControlMaster=no
           -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
@@ -78,6 +79,7 @@
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
+        ansible_pipelining: false
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/jenkins_ssh_config.yaml"
@@ -90,10 +92,16 @@
   hosts: "open5gs_vm"
   gather_facts: false
   tasks:
+    - name: Remove stale SSH ControlMaster socket left by previous builds
+      ansible.builtin.file:
+        path: "/tmp/ansible-ssh-{{ ansible_host }}-22-{{ ansible_user }}"
+        state: absent
+      delegate_to: localhost
+
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 600
+        timeout: 1800
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -71,8 +71,9 @@
         ansible_host: "{{ ips[access_vnet_id] }}"
         ansible_ssh_common_args: >-
           -F /dev/null
-          -S none
-          -o ControlMaster=no
+          -S /tmp/cm-{{ ips[access_vnet_id] }}-22-jenkins
+          -o ControlMaster=auto
+          -o ControlPersist=3600
           -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
@@ -93,7 +94,7 @@
   tasks:
     - name: Remove stale SSH ControlMaster socket left by previous builds
       ansible.builtin.file:
-        path: "/tmp/ansible-ssh-{{ ansible_host }}-22-{{ ansible_user }}"
+        path: "/tmp/cm-{{ ansible_host }}-22-{{ ansible_user }}"
         state: absent
       delegate_to: localhost
       vars:

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -107,6 +107,12 @@
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
 
+    - name: Wait for SSH to stabilize before first remote task
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
+        timeout: 300
+
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:
         user: jenkins

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -77,7 +77,6 @@
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
-        ansible_pipelining: true
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -73,7 +73,9 @@
           -F /dev/null
           -S none
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -116,7 +116,11 @@
             apt-daily-upgrade.timer \
             2>/dev/null || true
         echo '$nrconf{restart} = "l";' > /etc/needrestart/conf.d/00-ansible.conf 2>/dev/null || true
+        printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
         fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+        sleep 2
+        dpkg --configure -a 2>/dev/null || true
+        rm -f /usr/sbin/policy-rc.d
       become: true
       ignore_unreachable: true
       ignore_errors: true

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -104,9 +104,16 @@
         connect_timeout: 5
         timeout: 1800
 
-    - name: Stop unattended-upgrades to prevent sshd restart during configuration
+    - name: Mask apt automation to prevent sshd restarts during configuration
       ansible.builtin.shell: |
-        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        systemctl mask --now \
+            unattended-upgrades \
+            apt-daily.service \
+            apt-daily-upgrade.service \
+            apt-daily.timer \
+            apt-daily-upgrade.timer \
+            2>/dev/null || true
+        echo '$nrconf{restart} = "l";' > /etc/needrestart/conf.d/00-ansible.conf 2>/dev/null || true
         fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
       become: true
       ignore_unreachable: true

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -104,6 +104,20 @@
         connect_timeout: 5
         timeout: 1800
 
+    - name: Stop unattended-upgrades to prevent sshd restart during configuration
+      ansible.builtin.shell: |
+        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+      become: true
+      ignore_unreachable: true
+      ignore_errors: true
+
+    - name: Wait for SSH to stabilize after stopping unattended-upgrades
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
+        timeout: 300
+
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"
 

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -71,9 +71,8 @@
         ansible_host: "{{ ips[access_vnet_id] }}"
         ansible_ssh_common_args: >-
           -F /dev/null
-          -S /tmp/cm-{{ ips[access_vnet_id] }}-22-jenkins
-          -o ControlMaster=auto
-          -o ControlPersist=3600
+          -S none
+          -o ControlMaster=no
           -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
@@ -94,7 +93,7 @@
   tasks:
     - name: Remove stale SSH ControlMaster socket left by previous builds
       ansible.builtin.file:
-        path: "/tmp/cm-{{ ansible_host }}-22-{{ ansible_user }}"
+        path: "/tmp/ansible-ssh-{{ ansible_host }}-22-{{ ansible_user }}"
         state: absent
       delegate_to: localhost
       vars:

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -69,7 +69,7 @@
       ansible.builtin.add_host:
         hostname: "open5gs_vm"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }} -o KexAlgorithms=curve25519-sha256"
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -134,6 +134,19 @@
         delay: 5
         timeout: 300
 
+    - name: Wait for cloud-init to complete so sshd is no longer restarted
+      ansible.builtin.command:
+        cmd: cloud-init status --wait
+      changed_when: false
+      ignore_unreachable: true
+      ignore_errors: true
+
+    - name: Wait for SSH to stabilize after cloud-init
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
+        timeout: 300
+
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:
         user: jenkins

--- a/open5gs_vm/code/component_playbook.yaml
+++ b/open5gs_vm/code/component_playbook.yaml
@@ -79,7 +79,6 @@
           -o StrictHostKeyChecking=no
           -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
-        ansible_pipelining: false
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/jenkins_ssh_config.yaml"

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -41,9 +41,10 @@
             repo: 'ppa:open5gs/latest'
             state: present
 
-        - name: Install Open5GS 2.7.6~*
+        - name: Install Open5GS 2.8.0~*
           ansible.builtin.apt:
-            name: open5gs=2.7.6~*
+            name: open5gs=2.8.0~*
+            update_cache: yes
             state: present
       when: not one_open5gs_vm_use_nightly
 

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -25,7 +25,16 @@
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
         delay: 5
-        timeout: 120
+        timeout: 600
+      become: false
+      ignore_unreachable: true
+      ignore_errors: true
+
+    - name: Confirm SSH is stable after dpkg configure
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
+        timeout: 300
       become: false
 
     - name: Render netplan aliases

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -25,6 +25,13 @@
       changed_when: false
       when: netplan_changed.changed
 
+    - name: Wait for SSH to recover after netplan apply
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        timeout: 120
+      become: false
+      when: netplan_changed.changed
+
     - name: Install MongoDB 6
       block:
         - name: Import MongoDB 6 public key

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -2,17 +2,14 @@
 - name: Run every task as root user
   become: true
   block:
-    - name: Stop unattended-upgrades to release dpkg lock
-      ansible.builtin.systemd:
-        name: unattended-upgrades
-        state: stopped
+    - name: Release dpkg lock held by unattended-upgrades or apt
+      ansible.builtin.shell: |
+        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+        sleep 2
+        dpkg --configure -a 2>/dev/null || true
+      changed_when: false
       failed_when: false
-
-    - name: Wait for dpkg lock to be released
-      ansible.builtin.wait_for:
-        path: /var/lib/dpkg/lock-frontend
-        state: absent
-        timeout: 60
 
     - name: Render netplan aliases
       ansible.builtin.template:

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -2,9 +2,16 @@
 - name: Run every task as root user
   become: true
   block:
-    - name: Release dpkg lock held by unattended-upgrades or apt
+    - name: Release dpkg lock and suppress apt automation for the install
       ansible.builtin.shell: |
-        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        systemctl mask --now \
+            unattended-upgrades \
+            apt-daily.service \
+            apt-daily-upgrade.service \
+            apt-daily.timer \
+            apt-daily-upgrade.timer \
+            2>/dev/null || true
+        echo '$nrconf{restart} = "l";' > /etc/needrestart/conf.d/00-ansible.conf 2>/dev/null || true
         fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
         sleep 2
         dpkg --configure -a 2>/dev/null || true

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -2,6 +2,12 @@
 - name: Run every task as root user
   become: true
   block:
+    - name: Wait for dpkg lock to be released
+      ansible.builtin.wait_for:
+        path: /var/lib/dpkg/lock-frontend
+        state: absent
+        timeout: 300
+
     - name: Render netplan aliases
       ansible.builtin.template:
         src: "{{ workspace }}/{{ component_type }}/code/{{ site_hypervisor }}/cac/02_install/templates/99-netplan-aliases.yaml.j2"

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -2,11 +2,17 @@
 - name: Run every task as root user
   become: true
   block:
+    - name: Stop unattended-upgrades to release dpkg lock
+      ansible.builtin.systemd:
+        name: unattended-upgrades
+        state: stopped
+      failed_when: false
+
     - name: Wait for dpkg lock to be released
       ansible.builtin.wait_for:
         path: /var/lib/dpkg/lock-frontend
         state: absent
-        timeout: 300
+        timeout: 60
 
     - name: Render netplan aliases
       ansible.builtin.template:

--- a/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
+++ b/open5gs_vm/code/one/cac/02_install/install_open5gs.yml
@@ -12,11 +12,21 @@
             apt-daily-upgrade.timer \
             2>/dev/null || true
         echo '$nrconf{restart} = "l";' > /etc/needrestart/conf.d/00-ansible.conf 2>/dev/null || true
+        printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
         fuser -k /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
         sleep 2
         dpkg --configure -a 2>/dev/null || true
+        rm -f /usr/sbin/policy-rc.d
       changed_when: false
       failed_when: false
+      ignore_unreachable: true
+
+    - name: Wait for SSH to recover after dpkg configure
+      ansible.builtin.wait_for_connection:
+        connect_timeout: 5
+        delay: 5
+        timeout: 120
+      become: false
 
     - name: Render netplan aliases
       ansible.builtin.template:

--- a/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
+++ b/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =            "jenkins"
     SSH_PUBLIC_KEY =      "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
+++ b/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
+++ b/open5gs_vm/code/one/iac/open5gs_vm.tf.j2
@@ -8,11 +8,14 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
   memory      = {{ one_open5gs_vm_memory }}
 
   context = {
-    NETWORK =        "YES"
-    NETCFG_TYPE =    "interfaces"
-    SET_HOSTNAME =   "$NAME"
-    USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    NETWORK =             "YES"
+    NETCFG_TYPE =         "interfaces"
+    SET_HOSTNAME =        "$NAME"
+    USERNAME =            "jenkins"
+    SSH_PUBLIC_KEY =      "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/open5gs_vm/result_templates/ok_result.md.j2
+++ b/open5gs_vm/result_templates/ok_result.md.j2
@@ -25,7 +25,7 @@ Deployed Open5GS includes the following 5G Core components:
 If you need detailed information about Open5GS you can visit the official documentation: https://open5gs.org/open5gs/docs/guide/01-quickstart/
 
 Current versions:
-- Open5GS `v2.7.6`
+- Open5GS `v2.8.0`
 - Ubuntu 22.04
 
 ## Important information

--- a/opensand_gw/code/component_playbook.yaml
+++ b/opensand_gw/code/component_playbook.yaml
@@ -61,7 +61,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
 
     - name: Set site ssh key as authorized in jenkins user

--- a/opensand_gw/code/component_playbook.yaml
+++ b/opensand_gw/code/component_playbook.yaml
@@ -43,7 +43,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/opensand_gw/code/component_playbook.yaml
+++ b/opensand_gw/code/component_playbook.yaml
@@ -40,7 +40,14 @@
       ansible.builtin.add_host:
         hostname: "opensand_gw"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/opensand_gw/code/one/iac/opensand_gw.tf.j2
+++ b/opensand_gw/code/one/iac/opensand_gw.tf.j2
@@ -15,6 +15,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_gw/code/one/iac/opensand_gw.tf.j2
+++ b/opensand_gw/code/one/iac/opensand_gw.tf.j2
@@ -16,8 +16,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_gw/code/one/iac/opensand_gw.tf.j2
+++ b/opensand_gw/code/one/iac/opensand_gw.tf.j2
@@ -14,7 +14,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 

--- a/opensand_sat/code/component_playbook.yaml
+++ b/opensand_sat/code/component_playbook.yaml
@@ -40,7 +40,14 @@
       ansible.builtin.add_host:
         hostname: opensand_sat
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/opensand_sat/code/component_playbook.yaml
+++ b/opensand_sat/code/component_playbook.yaml
@@ -43,7 +43,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/opensand_sat/code/component_playbook.yaml
+++ b/opensand_sat/code/component_playbook.yaml
@@ -61,7 +61,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/opensand_sat/code/one/iac/opensand_sat.tf.j2
+++ b/opensand_sat/code/one/iac/opensand_sat.tf.j2
@@ -15,6 +15,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_sat/code/one/iac/opensand_sat.tf.j2
+++ b/opensand_sat/code/one/iac/opensand_sat.tf.j2
@@ -16,8 +16,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_sat/code/one/iac/opensand_sat.tf.j2
+++ b/opensand_sat/code/one/iac/opensand_sat.tf.j2
@@ -14,7 +14,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 

--- a/opensand_st/code/component_playbook.yaml
+++ b/opensand_st/code/component_playbook.yaml
@@ -43,7 +43,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/opensand_st/code/component_playbook.yaml
+++ b/opensand_st/code/component_playbook.yaml
@@ -40,7 +40,14 @@
       ansible.builtin.add_host:
         hostname: opensand_st
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/opensand_st/code/component_playbook.yaml
+++ b/opensand_st/code/component_playbook.yaml
@@ -61,7 +61,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/opensand_st/code/one/iac/opensand_st.tf.j2
+++ b/opensand_st/code/one/iac/opensand_st.tf.j2
@@ -15,6 +15,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_st/code/one/iac/opensand_st.tf.j2
+++ b/opensand_st/code/one/iac/opensand_st.tf.j2
@@ -16,8 +16,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 

--- a/opensand_st/code/one/iac/opensand_st.tf.j2
+++ b/opensand_st/code/one/iac/opensand_st.tf.j2
@@ -14,7 +14,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 

--- a/prometheus/code/component_playbook.yaml
+++ b/prometheus/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "prometheus"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/prometheus/code/component_playbook.yaml
+++ b/prometheus/code/component_playbook.yaml
@@ -74,7 +74,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/prometheus/code/component_playbook.yaml
+++ b/prometheus/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/prometheus/code/one/iac/prometheus.tf.j2
+++ b/prometheus/code/one/iac/prometheus.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_PROMETHEUS_VERSION =   "{{ one_prometheus_version }}"
   }
 

--- a/prometheus/code/one/iac/prometheus.tf.j2
+++ b/prometheus/code/one/iac/prometheus.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_PROMETHEUS_VERSION =   "{{ one_prometheus_version }}"
   }
 

--- a/prometheus/code/one/iac/prometheus.tf.j2
+++ b/prometheus/code/one/iac/prometheus.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_PROMETHEUS_VERSION =   "{{ one_prometheus_version }}"
   }
 

--- a/qosium_probe/code/component_playbook.yaml
+++ b/qosium_probe/code/component_playbook.yaml
@@ -54,7 +54,14 @@
       ansible.builtin.add_host:
         hostname: "qosium_probe"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/qosium_probe/code/component_playbook.yaml
+++ b/qosium_probe/code/component_playbook.yaml
@@ -79,7 +79,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Load enviromental variables from different sources
       ansible.builtin.include_tasks: "{{ workspace }}/.global/cac/load_variables.yaml"

--- a/qosium_probe/code/component_playbook.yaml
+++ b/qosium_probe/code/component_playbook.yaml
@@ -57,7 +57,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/qosium_probe/code/one/iac/qosium_probe.tf.j2
+++ b/qosium_probe/code/one/iac/qosium_probe.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME = "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a Terraform OpenNebula Provider's error

--- a/qosium_probe/code/one/iac/qosium_probe.tf.j2
+++ b/qosium_probe/code/one/iac/qosium_probe.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE= "interfaces"
     SET_HOSTNAME = "$NAME"
     USERNAME = "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a Terraform OpenNebula Provider's error

--- a/qosium_probe/code/one/iac/qosium_probe.tf.j2
+++ b/qosium_probe/code/one/iac/qosium_probe.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME = "$NAME"
     USERNAME = "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a Terraform OpenNebula Provider's error

--- a/tn_bastion/code/component_playbook.yaml
+++ b/tn_bastion/code/component_playbook.yaml
@@ -56,7 +56,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Wait again until one-appliance contextualization scripts have finished
       become: true

--- a/tn_bastion/code/one/iac/tn_bastion.tf.j2
+++ b/tn_bastion/code/one/iac/tn_bastion.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "tn_bastion" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     TOKEN = "YES"
     ONEAPP_BASTION_DNS_PASSWORD =          ""
     ONEAPP_BASTION_DNS_FORWARDERS =        "{{ site_dns | default('8.8.8.8,1.1.1.1') }}"

--- a/tn_bastion/code/one/iac/tn_bastion.tf.j2
+++ b/tn_bastion/code/one/iac/tn_bastion.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "tn_bastion" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     TOKEN = "YES"
     ONEAPP_BASTION_DNS_PASSWORD =          ""
     ONEAPP_BASTION_DNS_FORWARDERS =        "{{ site_dns | default('8.8.8.8,1.1.1.1') }}"

--- a/tn_bastion/code/one/iac/tn_bastion.tf.j2
+++ b/tn_bastion/code/one/iac/tn_bastion.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "tn_bastion" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     TOKEN = "YES"
     ONEAPP_BASTION_DNS_PASSWORD =          ""
     ONEAPP_BASTION_DNS_FORWARDERS =        "{{ site_dns | default('8.8.8.8,1.1.1.1') }}"

--- a/tn_init/code/component_playbook.yaml
+++ b/tn_init/code/component_playbook.yaml
@@ -56,7 +56,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Wait again until one-appliance contextualization scripts have finished
       become: true

--- a/ueransim/code/component_playbook.yaml
+++ b/ueransim/code/component_playbook.yaml
@@ -77,7 +77,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Wait again until one-appliance contextualization scripts have finished
       become: true

--- a/ueransim/code/component_playbook.yaml
+++ b/ueransim/code/component_playbook.yaml
@@ -56,7 +56,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/ueransim/code/component_playbook.yaml
+++ b/ueransim/code/component_playbook.yaml
@@ -53,7 +53,14 @@
       ansible.builtin.add_host:
         hostname: "ueransim"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/ueransim/code/one/iac/ueransim.tf.j2
+++ b/ueransim/code/one/iac/ueransim.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
 {% if one_ueransim_mode in ['gnb', 'both'] %}
     ONEAPP_UERANSIM_RUN_GNB = "{% if one_ueransim_run_gnb %}YES{% else %}NO{% endif %}"
     ONEAPP_UERANSIM_GNB_AMF_IP = "{{ one_ueransim_gnb_amf_n2_ip }}"

--- a/ueransim/code/one/iac/ueransim.tf.j2
+++ b/ueransim/code/one/iac/ueransim.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
 {% if one_ueransim_mode in ['gnb', 'both'] %}
     ONEAPP_UERANSIM_RUN_GNB = "{% if one_ueransim_run_gnb %}YES{% else %}NO{% endif %}"
     ONEAPP_UERANSIM_GNB_AMF_IP = "{{ one_ueransim_gnb_amf_n2_ip }}"

--- a/ueransim/code/one/iac/ueransim.tf.j2
+++ b/ueransim/code/one/iac/ueransim.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
 {% if one_ueransim_mode in ['gnb', 'both'] %}
     ONEAPP_UERANSIM_RUN_GNB = "{% if one_ueransim_run_gnb %}YES{% else %}NO{% endif %}"
     ONEAPP_UERANSIM_GNB_AMF_IP = "{{ one_ueransim_gnb_amf_n2_ip }}"

--- a/ueransim/sample-la-mayora.yaml
+++ b/ueransim/sample-la-mayora.yaml
@@ -1,0 +1,38 @@
+trial_network:
+  tn_init:
+    type: "tn_init"
+    dependencies: []
+    input: {}
+  vnet-n2:
+    type: "vnet"
+    name: "n2"
+    dependencies:
+      - "tn_init"
+    input:
+      one_vnet_first_ip: "10.10.10.1"
+      one_vnet_netmask: 24
+      one_vnet_address_size: 100
+  open5gs_vm-core:
+    type: "open5gs_vm"
+    name: "core"
+    dependencies:
+      - "vnet-n2"
+    input:
+      one_open5gs_vm_external_vnet: "tn_vxlan"
+      one_open5gs_vm_internal_vnet:
+        - "vnet-n2"
+      one_open5gs_vm_size: "small"
+      one_open5gs_vm_ue_subnet: "10.45.0.0/16"
+      one_open5gs_vm_amf_n2_ip: "10.10.10.200"
+      one_open5gs_vm_upf_n3_ip: "10.10.10.201"
+      one_open5gs_vm_s_nssai_sd: "000009"
+  ueransim-both:
+    type: "ueransim"
+    name: "both"
+    dependencies:
+      - "open5gs_vm-core"
+    input:
+      one_ueransim_networks:
+        - "tn_vxlan"
+      one_ueransim_mode: "both"
+      one_ueransim_gnb_linked_5gcore: "open5gs_vm-core"

--- a/upf_p4_sw/code/component_playbook.yaml
+++ b/upf_p4_sw/code/component_playbook.yaml
@@ -62,7 +62,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/upf_p4_sw/code/component_playbook.yaml
+++ b/upf_p4_sw/code/component_playbook.yaml
@@ -59,7 +59,14 @@
       ansible.builtin.add_host:
         hostname: "upf_p4_sw"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Display host inventory information

--- a/upf_p4_sw/code/component_playbook.yaml
+++ b/upf_p4_sw/code/component_playbook.yaml
@@ -92,7 +92,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/upf_p4_sw/code/one/cac/02_install/docker-compose.yaml
+++ b/upf_p4_sw/code/one/cac/02_install/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       
 # ---- Services for Open5GS ----
   mongo:
-    image: mongo
+    image: mongo:4.4
     environment:
       MONGO_INITDB_DATABASE: open5gs
     network_mode: host

--- a/upf_p4_sw/code/one/cac/02_install/docker_install.yaml
+++ b/upf_p4_sw/code/one/cac/02_install/docker_install.yaml
@@ -24,6 +24,11 @@
       - docker-compose-plugin
     state: present
 
+- name: Clean apt cache after Docker install
+  apt:
+    clean: true
+    autoremove: true
+
 - name: Add jenkins user to docker group
   user:
     name: jenkins

--- a/upf_p4_sw/code/one/cac/02_install/upf_p4_install.yaml
+++ b/upf_p4_sw/code/one/cac/02_install/upf_p4_install.yaml
@@ -67,6 +67,13 @@
 #        - docker-compose.yaml
 #      state: present
 
+- name: Pull docker-compose images
+  become: true
+  become_user: jenkins
+  command: docker compose -f /home/jenkins/docker-compose.yaml pull
+  args:
+    chdir: /home/jenkins
+
 - name: Execute docker-compose up
   become: true
   become_user: jenkins
@@ -78,8 +85,8 @@
   wait_for:
     host: 127.0.0.1
     port: 27017
-    delay: 5
-    timeout: 120
+    delay: 10
+    timeout: 300
     state: started
 
 # TODO: At the moment, only one UE is registed

--- a/upf_p4_sw/code/one/cac/02_install/upf_p4_install.yaml
+++ b/upf_p4_sw/code/one/cac/02_install/upf_p4_install.yaml
@@ -74,9 +74,13 @@
   args:
     chdir: /home/jenkins
 
-- name: Pause to wait for mongo to deployment
-  pause:
-    seconds: 5
+- name: Wait for MongoDB to be ready
+  wait_for:
+    host: 127.0.0.1
+    port: 27017
+    delay: 5
+    timeout: 120
+    state: started
 
 # TODO: At the moment, only one UE is registed
 - name: Apply template to UEs registration script

--- a/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
+++ b/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
@@ -12,8 +12,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {% for network in one_upf_p4_sw_networks %}

--- a/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
+++ b/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
@@ -11,6 +11,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {% for network in one_upf_p4_sw_networks %}

--- a/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
+++ b/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
@@ -10,7 +10,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {% for network in one_upf_p4_sw_networks %}

--- a/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
+++ b/upf_p4_sw/code/one/iac/upf_p4_sw.tf.j2
@@ -5,6 +5,11 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
   vcpu        = {{ one_upf_p4_sw_cpu }}
   memory      = {{ one_upf_p4_sw_memory }}
 
+  disk {
+    image_id = {{ site_available_components.upf_p4_sw.image_id }}
+    size     = {{ one_upf_p4_sw_disk }}
+  }
+
   context = {
     NETWORK =        "YES"
     NETCFG_TYPE =    "interfaces"

--- a/vm_kvm/code/component_playbook.yaml
+++ b/vm_kvm/code/component_playbook.yaml
@@ -56,7 +56,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/vm_kvm/code/component_playbook.yaml
+++ b/vm_kvm/code/component_playbook.yaml
@@ -53,7 +53,14 @@
       ansible.builtin.add_host:
         hostname: "vm_kvm"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add new VM to SSH config file in the Jenkins-master for debugging purposes

--- a/vm_kvm/code/component_playbook.yaml
+++ b/vm_kvm/code/component_playbook.yaml
@@ -77,7 +77,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/vm_kvm/code/one/iac/vm_kvm.tf.j2
+++ b/vm_kvm/code/one/iac/vm_kvm.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/vm_kvm/code/one/iac/vm_kvm.tf.j2
+++ b/vm_kvm/code/one/iac/vm_kvm.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/vm_kvm/code/one/iac/vm_kvm.tf.j2
+++ b/vm_kvm/code/one/iac/vm_kvm.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
   }
 
 {# ### Disabled the possibility to modify VM's size due to a problem with Terraform's OpenNebula Provider

--- a/xrext/code/component_playbook.yaml
+++ b/xrext/code/component_playbook.yaml
@@ -50,7 +50,14 @@
       ansible.builtin.add_host:
         hostname: "xrext"
         ansible_host: "{{ ips[access_vnet_id] }}"
-        ansible_ssh_common_args: "-J jenkins@{{ bastion_ip }}"
+        ansible_ssh_common_args: >-
+          -F /dev/null
+          -o ControlMaster=no
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
+          -o KexAlgorithms=curve25519-sha256
+          -o StrictHostKeyChecking=no
+          -o UserKnownHostsFile=/dev/null
         ansible_user: "jenkins"
 
     - name: Add the bastion to Ansible Inventory

--- a/xrext/code/component_playbook.yaml
+++ b/xrext/code/component_playbook.yaml
@@ -80,7 +80,7 @@
     - name: Wait for system to become reachable
       ansible.builtin.wait_for_connection:
         connect_timeout: 5
-        timeout: 200
+        timeout: 600
 
     - name: Set site ssh key as authorized in jenkins user
       ansible.posix.authorized_key:

--- a/xrext/code/component_playbook.yaml
+++ b/xrext/code/component_playbook.yaml
@@ -53,7 +53,9 @@
         ansible_ssh_common_args: >-
           -F /dev/null
           -o ControlMaster=no
-          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes jenkins@{{ bastion_ip }} nc %h %p"
+          -o ServerAliveInterval=30
+          -o ServerAliveCountMax=10
+          -o ProxyCommand="ssh -i /var/lib/jenkins/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o KexAlgorithms=curve25519-sha256 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=10 jenkins@{{ bastion_ip }} nc %h %p"
           -o IdentityFile=/var/lib/jenkins/.ssh/id_ed25519
           -o KexAlgorithms=curve25519-sha256
           -o StrictHostKeyChecking=no

--- a/xrext/code/one/iac/xrext.tf.j2
+++ b/xrext/code/one/iac/xrext.tf.j2
@@ -14,8 +14,8 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
-    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
-    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily and their timers and their timers
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBzdG9wIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCnN5c3RlbWN0bCBtYXNrIGFwdC1kYWlseS50aW1lciBhcHQtZGFpbHktdXBncmFkZS50aW1lciAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_XR_CAPIF_API_NAME = "{{ one_xr_capif_api_name }}"
     ONEAPP_XR_CAPIF_HTTPS_HOST = "{{ one_xr_capif_https_host }}"
     ONEAPP_XR_CAPIF_HTTPS_PORT = "{{ one_xr_capif_https_port }}"

--- a/xrext/code/one/iac/xrext.tf.j2
+++ b/xrext/code/one/iac/xrext.tf.j2
@@ -12,7 +12,7 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     NETCFG_TYPE =    "interfaces"
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
-    SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+    SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
     ONEAPP_XR_CAPIF_API_NAME = "{{ one_xr_capif_api_name }}"
     ONEAPP_XR_CAPIF_HTTPS_HOST = "{{ one_xr_capif_https_host }}"
     ONEAPP_XR_CAPIF_HTTPS_PORT = "{{ one_xr_capif_https_port }}"

--- a/xrext/code/one/iac/xrext.tf.j2
+++ b/xrext/code/one/iac/xrext.tf.j2
@@ -13,6 +13,9 @@ resource "opennebula_virtual_machine" "{{ entity_name }}" {
     SET_HOSTNAME =   "$NAME"
     USERNAME =       "jenkins"
     SSH_PUBLIC_KEY = "{{ jenkins_ssh_public_key }}"
+    # Disable unattended-upgrades at first boot to prevent sshd restarts during Ansible provisioning
+    # Script: systemctl stop/mask unattended-upgrades apt-daily-upgrade apt-daily
+    START_SCRIPT_BASE64 = "IyEvYmluL2Jhc2gKc3lzdGVtY3RsIHN0b3AgdW5hdHRlbmRlZC11cGdyYWRlcyBhcHQtZGFpbHktdXBncmFkZSBhcHQtZGFpbHkgMj4vZGV2L251bGwgfHwgdHJ1ZQpzeXN0ZW1jdGwgbWFzayB1bmF0dGVuZGVkLXVwZ3JhZGVzIGFwdC1kYWlseS11cGdyYWRlIGFwdC1kYWlseSAyPi9kZXYvbnVsbCB8fCB0cnVlCg=="
     ONEAPP_XR_CAPIF_API_NAME = "{{ one_xr_capif_api_name }}"
     ONEAPP_XR_CAPIF_HTTPS_HOST = "{{ one_xr_capif_https_host }}"
     ONEAPP_XR_CAPIF_HTTPS_PORT = "{{ one_xr_capif_https_port }}"


### PR DESCRIPTION
Deployment currently fails in the 6G-Library OneKE component because oneKE/code/component_playbook.yaml calls the hardcoded /usr/bin/onevm disk-resize, but Jenkins does not have a working OpenNebula CLI at that path.

Replace the hardcoded CLI invocation with the validated Ruby OpenNebula API path using OpenNebula::VirtualMachine#disk_resize(1, 30 * 1024).

Validation evidence from the UMA debugging session:

    Temporary branch: fix/uma-test-raul-oneke-onevm-path
    Validated commit: 5cbb61f5598d952df3d845136b16a66ca753bfda
    Fresh TN activation: lmql
    Jenkins job: TN_DEPLOY_lmql build #5 succeeded
    TNLCM status: lmql reached activated
